### PR TITLE
Remove check for scsi_transport_iscsi version, as it breaks on Slackware

### DIFF
--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1369,37 +1369,5 @@ char *iscsi_sysfs_get_iscsi_kernel_version(void)
 
 int iscsi_sysfs_check_class_version(void)
 {
-	char *version;
-	int i;
-
-	version = iscsi_sysfs_get_iscsi_kernel_version();
-	if (!version)
-		goto fail;
-
-	log_warning("transport class version %s. iscsid version %s",
-		    version, ISCSI_VERSION_STR);
-
-	for (i = 0; i < strlen(version); i++) {
-		if (version[i] == '-')
-			break;
-	}
-
-	if (i == strlen(version))
-		goto fail;
-
-	/*
-	 * We want to make sure the release and interface are the same.
-	 * It is ok for the svn versions to be different.
-	 */
-	if (!strncmp(version, ISCSI_VERSION_STR, i) ||
-	   /* support 2.6.18 */
-	    !strncmp(version, "1.1", 3))
-		return 0;
-
-fail:
-	log_error( "Missing or Invalid version from %s. Make sure a up "
-		"to date scsi_transport_iscsi module is loaded and a up to"
-		"date version of iscsid is running. Exiting...",
-		ISCSI_VERSION_FILE);
-	return -1;
+  return 0;
 }


### PR DESCRIPTION
This probably isn't the best way to handle this, but for now this is a quick-fix to let open-iscsi work on Slackware 13.37 and probably other versions.

The basic issue is that on Slackware with the default 2.6.37.6 kernel, there is no version parameter available through /sys/module/scsi_transport_iscsi/. I'm not sure why this is, the support is compiled into the default kernel and with this change applied iscsid and friends seem to work with no issues.
