### PR TITLE
fixed typo in iscsi_discovery usage()

### DIFF
--- a/utils/iscsi_discovery
+++ b/utils/iscsi_discovery
@@ -39,7 +39,7 @@ usage()
 	echo "Options:"
 	echo  "-p		set the port number (defualt is 3260)."
 	echo  "-d		print debugging information"
-	echo  "-t		set trasnpot (default is tcp)."
+	echo  "-t		set transport (default is tcp)."
 	echo  "-f		force specific transport -disable the fallback to tcp (default is fallback enabled)."
 	echo  "			force the transport specified by the argument of the -t flag."
 	echo  "-m		manual startup - will set manual startup (default is automatic startup)."


### PR DESCRIPTION
Noticed that the help for iscsi_discovery had a typo

changing "trasnpot" into "transport" so it looks better