### PR TITLE
iscsid: reset socket when session recovery

### DIFF
--- a/usr/io.c
+++ b/usr/io.c
@@ -394,6 +394,16 @@ iscsi_io_tcp_disconnect(iscsi_conn_t *conn)
 	if (conn->socket_fd >= 0) {
 		log_debug(1, "disconnecting conn %p, fd %d", conn,
 			 conn->socket_fd);
+		int ret = 0;
+		struct linger so_linger;
+		so_linger.l_onoff = 1;
+		so_linger.l_linger = 0;
+		ret = setsockopt(conn->socket_fd, SOL_SOCKET, SO_LINGER,
+			&so_linger, sizeof(so_linger));
+		if (ret) {
+		     log_debug(1, "setsockopt failed conn %p, fd %d",
+			conn, conn->socket_fd);
+		}
 		close(conn->socket_fd);
 		conn->socket_fd = -1;
 	}


### PR DESCRIPTION
Close without linger setting would not reset socket, corrupted data
could been sent to target server when tcp retry.

Signed-off-by: Guangliang Zhao <lucienchao@gmail.com>