### PR TITLE
iBFT 'origin' is an enum, not a string

### DIFF
--- a/utils/fwparam_ibft/fwparam_ibft_sysfs.c
+++ b/utils/fwparam_ibft/fwparam_ibft_sysfs.c
@@ -201,8 +201,7 @@ static int fill_nic_context(char *id, struct boot_context *context)
 		      sizeof(context->secondary_dns));
 	sysfs_get_str(id, IBFT_SUBSYS, "dhcp", context->dhcp,
 		      sizeof(context->dhcp));
-	sysfs_get_str(id, IBFT_SUBSYS, "origin", context->origin,
-		      sizeof(context->origin));
+	sysfd_get_int(id, IBFT_SUBSYS, "origin", &context->origin);
 	return 0;
 }
 


### PR DESCRIPTION
A recent change, commit 4959a89f421fdebc, modified open-iscsi
to treat the "origin" field as an enum, not a character
string. But one spot was missed.