### PR TITLE
fix musl on open-iscsi

### DIFF
--- a/iscsiuio/src/unix/libs/bnx2x.c
+++ b/iscsiuio/src/unix/libs/bnx2x.c
@@ -42,7 +42,7 @@
 #include <arpa/inet.h>
 #include <linux/types.h>	/* Needed for linux/ethtool.h on RHEL 5.x */
 #include <linux/sockios.h>
-#include <linux/ethtool.h>
+#include "ethtool-compat.h"
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/iscsiuio/src/unix/libs/ethtool-compat.h
+++ b/iscsiuio/src/unix/libs/ethtool-compat.h
@@ -1,0 +1,51 @@
+/*
+ * ethtool-compat.h: adopted from
+ # ethtool.h: Defines for Linux ethtool.
+ *
+ * Copyright (C) 1998 David S. Miller (davem@redhat.com)
+ * Copyright 2001 Jeff Garzik <jgarzik@pobox.com>
+ * Portions Copyright 2001 Sun Microsystems (thockin@sun.com)
+ * Portions Copyright 2002 Intel (eli.kupermann@intel.com,
+ *                                christopher.leech@intel.com,
+ *                                scott.feldman@intel.com)
+ * Portions Copyright (C) Sun Microsystems 2008
+ */
+
+#include <linux/types.h>
+#include <netinet/if_ether.h>
+
+#define ETHTOOL_FWVERS_LEN	32
+#define ETHTOOL_BUSINFO_LEN	32
+#define ETHTOOL_EROMVERS_LEN	32
+
+struct ethtool_drvinfo {
+	__u32	cmd;
+	char	driver[32];
+	char	version[32];
+	char	fw_version[ETHTOOL_FWVERS_LEN];
+	char	bus_info[ETHTOOL_BUSINFO_LEN];
+	char	erom_version[ETHTOOL_EROMVERS_LEN];
+	char	reserved2[12];
+	__u32	n_priv_flags;
+	__u32	n_stats;
+	__u32	testinfo_len;
+	__u32	eedump_len;
+	__u32	regdump_len;
+};
+
+struct ethtool_tcpip4_spec {
+	__be32	ip4src;
+	__be32	ip4dst;
+	__be16	psrc;
+	__be16	pdst;
+	__u8    tos;
+};
+
+struct ethtool_ah_espip4_spec {
+	__be32	ip4src;
+	__be32	ip4dst;
+	__be32	spi;
+	__u8    tos;
+};
+
+#define ETHTOOL_GDRVINFO	0x00000003 /* Get driver info. */

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <dirent.h>
 #include <limits.h>
 #include <sys/stat.h>

--- a/utils/fwparam_ibft/fwparam_ppc.c
+++ b/utils/fwparam_ibft/fwparam_ppc.c
@@ -356,7 +356,7 @@ static int loop_devs(const char *devtree)
 	 * Sort the nics into "natural" order.	The proc fs
 	 * device-tree has them in somewhat random, or reversed order.
 	 */
-	qsort(niclist, nic_count, sizeof(char *), (__compar_fn_t)nic_cmp);
+	qsort(niclist, nic_count, sizeof(char *), (int (*)(const void *, const void *))nic_cmp);
 
 	snprintf(prefix, sizeof(prefix), "%s/%s", devtree, "aliases");
 	dev_count = 0;


### PR DESCRIPTION
Portions of this patch have been taken from Alpine [1] and Gentoo [2].

This patch has been tested on glibc and musl systems.

[1] http://git.alpinelinux.org/cgit/aports/log/main/open-iscsi/musl-fixes.patch
[2] https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=da400dec15a2987751259860fea158bf252b3baa