### PR TITLE
Fix manual LUN scans feature

### DIFF
--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1883,18 +1883,19 @@ void iscsi_sysfs_rescan_device(void *data, int hostno, int target, int lun)
 			strlen(write_buf));
 }
 
-pid_t iscsi_sysfs_scan_host(int hostno, int async, int full_scan)
+pid_t iscsi_sysfs_scan_host(int hostno, int async, int autoscan)
 {
 	char id[NAME_SIZE];
-	char write_buf[6] = "- - 0";
+	char *write_buf = "- - -";
 	pid_t pid = 0;
-
-	if (full_scan)
-		write_buf[4] = '-';
 
 	if (async)
 		pid = fork();
-	if (pid == 0) {
+
+	if (pid >= 0 && !autoscan) {
+		if (pid)
+			log_debug(4, "host%d in manual scan mode, skipping scan", hostno);
+	} else if (pid == 0) {
 		/* child */
 		log_debug(4, "scanning host%d", hostno);
 

--- a/usr/iscsi_sysfs.h
+++ b/usr/iscsi_sysfs.h
@@ -87,7 +87,7 @@ extern void iscsi_sysfs_get_negotiated_session_conf(int sid,
 				struct iscsi_session_operational_config *conf);
 extern void iscsi_sysfs_get_negotiated_conn_conf(int sid,
 				struct iscsi_conn_operational_config *conf);
-extern pid_t iscsi_sysfs_scan_host(int hostno, int async, int full);
+extern pid_t iscsi_sysfs_scan_host(int hostno, int async, int autoscan);
 extern int iscsi_sysfs_get_session_state(char *state, int sid);
 extern int iscsi_sysfs_get_host_state(char *state, int host_no);
 extern int iscsi_sysfs_get_device_state(char *state, int host_no, int target,


### PR DESCRIPTION
The newly introduced feature to disable automatic scans should not be
scanning *any* of the LUNs when the scan is set to manual, but it always
scans for LUN0.

This patch fixes this by skipping the sysfs call altogether, as it
should have been doing from the start.