### PR TITLE
Fix coredump when printing sessio info at level 1 or higher

### DIFF
--- a/usr/session_info.c
+++ b/usr/session_info.c
@@ -423,8 +423,7 @@ int session_info_print(int info_level, struct session_info *info, int do_show)
 		if (err || !num_found)
 			break;
 
-		session_info_print_tree(&list, "", flags, do_show,
-					info->iscsid_req_tmo);
+		session_info_print_tree(&list, "", flags, do_show, -1);
 		session_info_free_list(&list);
 		break;
 	default:


### PR DESCRIPTION
A recent commit 2b099d7b7e04b "Use timeout when waiting for responses from iscsid" introduced a bug in session_info_print() when running "iscsiadm -m session -P <LEVEL>", where LEVEL was 1 or 2. The bug was that "info" was being dereferenced to get a timeout value when "info" was NULL. This fix just uses the default timeout in that case and testing has shown it fixes the issue.