### PR TITLE
Add bnx2{,x} software initiator IBFT support

### DIFF
--- a/include/iscsi_net_util.h
+++ b/include/iscsi_net_util.h
@@ -2,6 +2,7 @@
 #define __ISCSI_NET_UTIL_h__
 
 #define ISCSI_HWADDRESS_BUF_SIZE 18
+#define ISCSIUIO_PATH "/sbin/iscsiuio"
 
 extern int net_get_transport_name_from_netdev(char *netdev, char *transport);
 extern int net_get_netdev_from_hwaddress(char *hwaddress, char *netdev);

--- a/iscsiuio/docs/iscsiuio.8
+++ b/iscsiuio/docs/iscsiuio.8
@@ -45,7 +45,7 @@ on how to configure network protocol and address.
 .SH PARAMETERS
 There are very few parameters when running this application.
 .TP
-.BI -d <debug level>
+.BI -d|--debug <debug level>
 This is to enable debug mode where debug messages will be sent to stdout
 The following debug modes are supported
 .P
@@ -61,20 +61,20 @@ ERROR         1 - Only print critical errors
 .PP
 .TP
 .TP
-.BI -f
+.BI -f|--foreground
 This is to enable foreground mode so that this application doesn't get sent
 into the background.
 .PP
 .TP
-.BI -v
+.BI -v|--version
 This is to print the version.
 .PP
 .TP
-.BI -p <pidfile>
+.BI -p|--pid <pidfile>
 Use pidfile (default  /var/run/iscsiuio.pid )
 .PP
 .TP
-.BI -h
+.BI -h|--help
 Display this help and exit.
 
 

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -82,10 +82,12 @@ static const char default_pid_filepath[] = "/var/run/iscsiuio.pid";
  *  Global Variables
  ******************************************************************************/
 static const struct option long_options[] = {
-	{"debug", 0, 0, 0},
-	{"version", 0, 0, 0},
-	{"help", 0, 0, 0},
-	{0, 0, 0, 0}
+	{"foreground", no_argument, NULL, 'f'},
+	{"debug", required_argument, NULL, 'd'},
+	{"pid", required_argument, NULL, 'p'},
+	{"version", no_argument, NULL, 'v'},
+	{"help", no_argument, NULL, 'h'},
+	{NULL, no_argument, NULL, 0}
 };
 
 struct options opt = {
@@ -172,7 +174,7 @@ static void main_usage()
 	printf("iscsiuio daemon.\n"
 	       "-f, --foreground        make the program run in the foreground\n"
 	       "-d, --debug debuglevel  print debugging information\n"
-	       "-p, --pid=pidfile       use pid file (default  %s).\n"
+	       "-p, --pid pidfile       use pid file (default  %s).\n"
 	       "-h, --help              display this help and exit\n"
 	       "-v, --version           display version and exit\n",
 	       default_pid_filepath);

--- a/utils/fwparam_ibft/fw_entry.c
+++ b/utils/fwparam_ibft/fw_entry.c
@@ -64,26 +64,40 @@ int fw_setup_nics(void)
 	 * For each target in iBFT bring up required NIC and use routing
 	 * to force iSCSI traffic through correct NIC
 	 */
-	list_for_each_entry(context, &targets, list) {			
-		/* if it is a offload nic ignore it */
-		if (!net_get_transport_name_from_netdev(context->iface,
-							transport))
-			continue;
-
+	list_for_each_entry(context, &targets, list) {
 		if (iface_prev == NULL || strcmp(context->iface, iface_prev)) {
-			/* Note: test above works because there is a
-			 * maximum of two targets in the iBFT
-			 */
-			iface_prev = context->iface;
-			needs_bringup = 1;
+				/* Note: test above works because there is a
+				 * maximum of two targets in the iBFT
+				 */
+				iface_prev = context->iface;
+				needs_bringup = 1;
 		}
+		if (net_get_transport_name_from_netdev(context->iface, transport)) {
+			/* Setup software NIC, */
+			printf("Setting up software interface %s\n", context->iface);
+			err = net_setup_netdev(context->iface, context->ipaddr,
+								   context->mask, context->gateway,
+								   context->vlan,
+								   context->target_ipaddr, needs_bringup);
+			if (err) {
+				printf("Setting up software interface %s failed\n",
+						context->iface);
+				ret = err;
+			}
+		} else {
+			/* Setup offload NIC. */
+			struct iface_rec iface;
 
-		err = net_setup_netdev(context->iface, context->ipaddr,
-				       context->mask, context->gateway,
-				       context->vlan,
-				       context->target_ipaddr, needs_bringup);
-		if (err)
-			ret = err;
+			memset(&iface, 0, sizeof(iface));
+			iface_setup_defaults(&iface);
+			printf("Setting up offload interface %s\n", context->iface);
+			if (!iface_setup_from_boot_context(&iface, context)) {
+					printf("Setting up offload interface %s failed\n",
+						   context->iface);
+
+					ret = ISCSI_ERR;
+			}
+		}
 	}
 
 	fw_free_targets(&targets);
@@ -147,11 +161,7 @@ void fw_free_targets(struct list_head *list)
 
 static void dump_initiator(struct boot_context *context)
 {
-	struct iface_rec iface;
-
-	memset(&iface, 0, sizeof(iface));
-	iface_setup_defaults(&iface);
-	iface_setup_from_boot_context(&iface, context);
+	char transport_name[ISCSI_TRANSPORT_NAME_MAXLEN];
 
 	if (strlen(context->initiatorname))
 		printf("%s = %s\n", IFACE_INAME, context->initiatorname);
@@ -159,7 +169,9 @@ static void dump_initiator(struct boot_context *context)
 	if (strlen(context->isid))
 		printf("%s = %s\n", IFACE_ISID, context->isid);
 
-	printf("%s = %s\n", IFACE_TRANSPORTNAME, iface.transport_name);
+	memset(transport_name, 0, ISCSI_TRANSPORT_NAME_MAXLEN);
+	if (!net_get_transport_name_from_netdev(context->iface, transport_name))
+		printf("%s = %s\n", IFACE_TRANSPORTNAME, transport_name);
 }
 
 static void dump_target(struct boot_context *context)


### PR DESCRIPTION
Add support in iscsistart for bnx2{,x} software initiators. This allows boot from iSCSI for devices that either cannot support iSCSI hardware offload or are configured in firmware not to support it.

The scsistart -N option will now bring up the interface (but not configure it) as specified in the IBFT for hardware offload devices.

Note: I cannot find a way to programmatically determine whether a bnx2{,x} device is configured for
hardware or software, so we check for the presence of the iscsiuio executable as an indication that hardware offload is being used.

