### PR TITLE
Inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.

### DIFF
--- a/iscsiuio/src/unix/libs/bnx2.c
+++ b/iscsiuio/src/unix/libs/bnx2.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <sys/mman.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/user.h>

--- a/iscsiuio/src/unix/libs/bnx2x.c
+++ b/iscsiuio/src/unix/libs/bnx2x.c
@@ -45,6 +45,7 @@
 #include <linux/ethtool.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/user.h>


### PR DESCRIPTION
Release notes for glibc-2.25 state:

The inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.
This means that in a future release, the macros “major”, “minor”, and
“makedev” will only be available from <sys/sysmacros.h>.

These macros are not part of POSIX nor XSI, and their names frequently
collide with user code; see for instance glibc bug 19239 and Red Hat
bug 130601. <stdlib.h> includes <sys/types.h> under _GNU_SOURCE, and
C++ code presently cannot avoid being compiled under _GNU_SOURCE,
exacerbating the problem.

This results in the following errors:
bnx2.c: In function ‘bnx2_open’:
bnx2.c:482:19: warning: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Wimplicit-function-declaration]
  nic->uio_minor = minor(uio_stat.st_rdev);

bnx2x.c: In function ‘bnx2x_open’:
bnx2x.c:754:19: warning: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Wimplicit-function-declaration]
  nic->uio_minor = minor(uio_stat.st_rdev)

bnx2.c:(.text+0xdb0): undefined reference to `minor'
../../src/unix/libs/lib_iscsiuio_hw_cnic.a(bnx2x.o): In function `bnx2x_open.part.13':
bnx2x.c:(.text+0x1548): undefined reference to `minor'
