### PR TITLE
make open-iscsi compatable with musl-libc

### DIFF
--- a/iscsiuio/src/unix/libs/bnx2x.c
+++ b/iscsiuio/src/unix/libs/bnx2x.c
@@ -36,6 +36,7 @@
  * bnx2x.c - bnx2x user space driver
  *
  */
+#include <netinet/if_ether.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <dirent.h>
 #include <limits.h>
 #include <sys/stat.h>

--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -31,7 +31,7 @@
 #include <linux/sockios.h>
 #include <linux/if_vlan.h>
 #include <net/if_arp.h>
-#include <linux/if_ether.h>
+#include <netinet/if_ether.h>
 
 #include "sysdeps.h"
 #include "ethtool-copy.h"

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -3265,6 +3265,7 @@ main(int argc, char **argv)
 	int tpgt = PORTAL_GROUP_TAG_UNKNOWN, killiscsid=-1, do_show=0;
 	int packet_size=32, ping_count=1, ping_interval=0;
 	int do_discover = 0, sub_mode = -1;
+	int argerror = 0;
 	int portal_type = -1;
 	int timeout = ISCSID_REQ_TIMEOUT;
 	struct sigaction sa_old;
@@ -3431,6 +3432,10 @@ main(int argc, char **argv)
 			break;
 		case 'h':
 			usage(0);
+			break;
+		case '?':
+			log_error("unrecognized character '%c'", optopt);
+			argerror = 1;
 		}
 
 		if (name && value) {
@@ -3446,8 +3451,7 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (optopt) {
-		log_error("unrecognized character '%c'", optopt);
+	if (argerror) {
 		rc = ISCSI_ERR_INVAL;
 		goto free_ifaces;
 	}

--- a/utils/fwparam_ibft/fwparam_ppc.c
+++ b/utils/fwparam_ibft/fwparam_ppc.c
@@ -356,7 +356,7 @@ static int loop_devs(const char *devtree)
 	 * Sort the nics into "natural" order.	The proc fs
 	 * device-tree has them in somewhat random, or reversed order.
 	 */
-	qsort(niclist, nic_count, sizeof(char *), (__compar_fn_t)nic_cmp);
+	qsort(niclist, nic_count, sizeof(char *), (int (*)(const void *, const void *))nic_cmp);
 
 	snprintf(prefix, sizeof(prefix), "%s/%s", devtree, "aliases");
 	dev_count = 0;


### PR DESCRIPTION
Use argerror instead of optopt for musl compatibility
  It looks like musl sets "optopt" in the getopt_long(3) code now, and
  that breaks iscsiadm's assumptions.  So change to use argerror instead.

Include if_ether from the installed libc instead of linux_headers, this also
imports from linux_headers and helps ensure libc compatability.

Include fcntl.h as it's needed on musl.

Fix sort line to work on musl (__compar_fn_t is not available).