### PR TITLE
Ignore common build output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.o
+cscope.files
+cscope.out
+TAGS
+tags


### PR DESCRIPTION
After years of see these build files listed when I do "git status", I'm ready to add them to the ignore list.