### PR TITLE
Automate logging into iSCSI FW targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,16 @@ bindir = $(exec_prefix)/bin
 mandir = $(prefix)/share/man
 etcdir = /etc
 initddir = $(etcdir)/init.d
+rulesdir = $(etcdir)/udev/rules.d
 
-MANPAGES = doc/iscsid.8 doc/iscsiadm.8 doc/iscsi_discovery.8 iscsiuio/docs/iscsiuio.8
-PROGRAMS = usr/iscsid usr/iscsiadm utils/iscsi_discovery utils/iscsi-iname iscsiuio/src/unix/iscsiuio
+MANPAGES = doc/iscsid.8 doc/iscsiadm.8 doc/iscsi_discovery.8 \
+		iscsiuio/docs/iscsiuio.8 doc/iscsi_fw_login.8
+PROGRAMS = usr/iscsid usr/iscsiadm utils/iscsi-iname iscsiuio/src/unix/iscsiuio
+SCRIPTS = utils/iscsi_discovery utils/iscsi_fw_login
 INSTALL = install
 ETCFILES = etc/iscsid.conf
 IFACEFILES = etc/iface.example
+RULESFILES = utils/50-iscsi-firmware-login.rules
 
 # Compatibility: parse old OPTFLAGS argument
 ifdef OPTFLAGS
@@ -92,7 +96,11 @@ install: install_programs install_doc install_etc \
 install_user: install_programs install_doc install_etc \
 	install_initd install_iname install_iface
 
-install_programs:  $(PROGRAMS)
+install_udev_rules:
+	$(INSTALL) -d $(DESTDIR)$(rulesdir)
+	$(INSTALL) -m 644 $(RULESFILES) $(DESTDIR)/$(rulesdir)
+
+install_programs:  $(PROGRAMS) $(SCRIPTS)
 	$(INSTALL) -d $(DESTDIR)$(sbindir)
 	$(INSTALL) -m 755 $^ $(DESTDIR)$(sbindir)
 

--- a/doc/iscsi_fw_login.8
+++ b/doc/iscsi_fw_login.8
@@ -1,0 +1,16 @@
+.TH "iscsi_fw_login" 8
+.SH NAME
+iscsi_fw_login \- Login to all iSCSI Firmware targets
+.SH SYNOPSIS
+.B iscsi_fw_login
+.SH DESCRIPTION
+This helper function logs into all known iSCSI firmware targets.
+.P
+It is meant as a helper function to be called by udev when new
+firmware targets are detected asynchronously.
+.SH AUTHOR
+Written by Lee Duncan
+.SH "REPORTING BUGS"
+Report bugs to <lduncan@suse.com>.
+.SH COPYRIGHT
+Copyright \(co 2015 Lee Duncan <lduncan@suse.com>

--- a/utils/50-iscsi-firmware-login.rules
+++ b/utils/50-iscsi-firmware-login.rules
@@ -1,0 +1,15 @@
+# This file contains the rules to handle iscsi firmware changes
+
+# DO NOT WRAP THIS LINE
+#
+# old udev does not understand some of it,
+# and would end up skipping only some lines, not the full rule.
+# which can cause all sort of trouble with strange-named device nodes
+# for completely unrelated devices,
+# resulting in unusable network lookback, etc.
+#
+# in case this is "accidentally" installed on a system with old udev,
+# having it as one single line avoids those problems.
+#
+# DO NOT WRAP THIS LINE
+SUBSYSTEM=="iscsi_boot*", ACTION=="add", DEVPATH=="*/target*", RUN+="/sbin/iscsi_fw_login"

--- a/utils/iscsi_fw_login
+++ b/utils/iscsi_fw_login
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# iscsi_fw_login -- login to iscsi firmware targets, if any
+#
+# This script is called when udev discovers a new iscsi
+# firmware target
+#
+
+ARGS="-m fw -l"
+ISCSIADM="/sbin/iscsiadm"
+
+$ISCSIADM $ARGS


### PR DESCRIPTION
Add a script that logs into all iSCSI firmware
targets, and add a udev rule to call that script
when new targets are detected. Also, add a
man page for the script.