### PR TITLE
Update iscsid.conf attribute iscsid.startup.

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -10,17 +10,19 @@
 ######################
 # iscsid daemon config
 ######################
+#
 # If you want iscsid to start the first time an iscsi tool
 # needs to access it, instead of starting it when the init
 # scripts run, set the iscsid startup command here. This
 # should normally only need to be done by distro package
-# maintainers.
+# maintainers. If you leave the iscsid daemon running all
+# the time then leave this attribute commented out.
 #
 # Default for Fedora and RHEL. (uncomment to activate).
-# iscsid.startup = /etc/rc.d/init.d/iscsid force-start
+# iscsid.startup = /bin/systemctl start iscsid.socket iscsiuio.soccket
 # 
-# Default for upstream open-iscsi scripts (uncomment to activate).
-iscsid.startup = /sbin/iscsid
+# Default if you are not using systemd (uncomment to activate)
+# iscsid.startup = /usr/bin/service start iscsid
 
 # Check for active mounts on devices reachable through a session
 # and refuse to logout if there are any.  Defaults to "No".


### PR DESCRIPTION
The comments for this attribute were outdated. In
general, with systemd, we do not want to manually
start the iscsid daemon ourselves.