### PR TITLE
Add in tracking IP prefix length, in addition to mask.

### DIFF
--- a/include/fw_context.h
+++ b/include/fw_context.h
@@ -60,6 +60,7 @@ struct boot_context {
 	/* network settings */
 	int nic_flags;
 	enum ibft_ip_prefix_origin origin;
+	int prefix;
 	char dhcp[NI_MAXHOST];
 	char iface[IF_NAMESIZE];
 	char mac[18];

--- a/usr/config.h
+++ b/usr/config.h
@@ -226,6 +226,7 @@ typedef struct iface_rec {
 	char			ipv6_autocfg[NI_MAXHOST];
 	char			linklocal_autocfg[NI_MAXHOST];
 	char			router_autocfg[NI_MAXHOST];
+	uint8_t			prefix_len;
 	uint16_t		vlan_id;
 	uint8_t			vlan_priority;
 	char			vlan_state[ISCSI_MAX_STR_LEN];

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -264,6 +264,8 @@ idbm_recinfo_node(node_rec_t *r, recinfo_t *ri)
 	__recinfo_str(IFACE_NETNAME, ri, r, iface.netdev, IDBM_SHOW, num, 1);
 	__recinfo_str(IFACE_GATEWAY, ri, r, iface.gateway, IDBM_SHOW, num, 1);
 	__recinfo_str(IFACE_SUBNET_MASK, ri, r, iface.subnet_mask, IDBM_SHOW, num, 1);
+	__recinfo_uint8(IFACE_PREFIX_LEN, ri, r, iface.prefix_len,
+			IDBM_SHOW, num, 1);
 	/*
 	 * svn 780 compat: older versions used node.transport_name and
 	 * rec->transport_name
@@ -534,6 +536,7 @@ void idbm_recinfo_iface(iface_rec_t *r, recinfo_t *ri)
 	__recinfo_str(IFACE_ISCSINAME, ri, r, name, IDBM_SHOW, num, 0);
 	__recinfo_str(IFACE_NETNAME, ri, r, netdev, IDBM_SHOW, num, 1);
 	__recinfo_str(IFACE_IPADDR, ri, r, ipaddress, IDBM_SHOW, num, 1);
+	__recinfo_uint8(IFACE_PREFIX_LEN, ri, r, prefix_len, IDBM_SHOW, num, 1);
 	__recinfo_str(IFACE_HWADDR, ri, r, hwaddress, IDBM_SHOW, num, 1);
 	__recinfo_str(IFACE_TRANSPORTNAME, ri, r, transport_name,
 		      IDBM_SHOW, num, 1);

--- a/usr/idbm_fields.h
+++ b/usr/idbm_fields.h
@@ -74,6 +74,7 @@
 #define IFACE_ISID		"iface.isid"
 #define IFACE_BOOT_PROTO	"iface.bootproto"
 #define IFACE_IPADDR		"iface.ipaddress"
+#define IFACE_PREFIX_LEN	"iface.prefix_len"
 #define IFACE_SUBNET_MASK	"iface.subnet_mask"
 #define IFACE_GATEWAY		"iface.gateway"
 #define IFACE_PRIMARY_DNS	"iface.primary_dns"

--- a/utils/fwparam_ibft/fw_entry.c
+++ b/utils/fwparam_ibft/fw_entry.c
@@ -215,6 +215,8 @@ static void dump_network(struct boot_context *context)
 		printf("%s = STATIC\n", IFACE_BOOT_PROTO);
 	if (strlen(context->ipaddr))
 		printf("%s = %s\n", IFACE_IPADDR, context->ipaddr);
+	if (context->prefix)
+		printf("%s = %d\n", IFACE_PREFIX_LEN, context->prefix);
 	if (strlen(context->mask))
 		printf("%s = %s\n", IFACE_SUBNET_MASK, context->mask);
 	if (strlen(context->gateway))

--- a/utils/fwparam_ibft/fwparam_sysfs.c
+++ b/utils/fwparam_ibft/fwparam_sysfs.c
@@ -221,6 +221,7 @@ static int fill_nic_context(char *subsys, char *id,
 		      sizeof(context->vlan));
 	sysfs_get_str(id, subsys, "subnet-mask", context->mask,
 		      sizeof(context->mask));
+	sysfs_get_int(id, subsys, "prefix-len", &context->prefix);
 	sysfs_get_str(id, subsys, "gateway", context->gateway,
 		      sizeof(context->gateway));
 	sysfs_get_str(id, subsys, "primary-dns", context->primary_dns,


### PR DESCRIPTION
The modern IP standard stresses the IP prefix length
rather than the network mask, so track the IP prefix length
from sysfs and in the interface DB.