### PR TITLE
Discovery via non-tcp transport needs "ipc" value

### DIFF
--- a/usr/discoveryd.c
+++ b/usr/discoveryd.c
@@ -1034,11 +1034,6 @@ static void __do_st_disc_and_login(struct discovery_rec *drec)
 	drec->u.sendtargets.reopen_max = 0;
 
 	iface_link_ifaces(&setup_ifaces);
-	/*
-	 * disc code assumes this is not set and wants to use
-	 * the userspace IO code.
-	 */
-	ipc = NULL;
 
 	rc = idbm_bind_ifaces_to_nodes(discovery_sendtargets, drec,
 					&setup_ifaces, &rec_list);


### PR DESCRIPTION
The "ipc" variable was being set to NULL because
the discovery code was thought to rely on that
value, but that was not the case, and non-tcp
transport needs this variable set to its
default (non-null) value to work.