### PR TITLE
Gcc 8 fixes -- clean up some string handling corner cases, and to make compiler happy

### DIFF
--- a/iscsiuio/src/unix/nic_utils.c
+++ b/iscsiuio/src/unix/nic_utils.c
@@ -305,7 +305,7 @@ static int nic_util_enable_disable_multicast(nic_t *nic, uint32_t cmd)
 	/* Prepare the request */
 	memset(&ifr, 0, sizeof(ifr));
 	strncpy(ifr.ifr_name, nic->eth_device_name,
-		sizeof(nic->eth_device_name));
+		sizeof(ifr.ifr_name));
 	memcpy(ifr.ifr_hwaddr.sa_data, multicast_addr.addr, ETH_ALEN);
 
 	fd = socket(AF_INET, SOCK_DGRAM, 0);

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -311,6 +311,9 @@ int _iscsi_host_id_of_session(struct iscsi_context *ctx, uint32_t sid,
 	int n = 0;
 	const char *host_id_str = NULL;
 	int i = 0;
+	const char iscsi_host_dir_str[] = "/iscsi_host/";
+	const unsigned int iscsi_host_dir_strlen = strlen(iscsi_host_dir_str);
+
 
 	assert(ctx != NULL);
 	assert(sid != 0);
@@ -323,8 +326,16 @@ int _iscsi_host_id_of_session(struct iscsi_context *ctx, uint32_t sid,
 
 	_good(sysfs_get_dev_path(ctx, sys_se_dir_path, sys_dev_path), rc, out);
 
-	snprintf(sys_scsi_host_dir_path, PATH_MAX, "%s/iscsi_host/",
-		 sys_dev_path);
+	if ((strlen(sys_dev_path) + iscsi_host_dir_strlen) >= PATH_MAX) {
+		rc = LIBISCSI_ERR_SYSFS_LOOKUP;
+		_error(ctx, "Pathname too long: %s%s",
+		       sys_dev_path, iscsi_host_dir_str);
+		goto out;
+	}
+
+	strncpy(sys_scsi_host_dir_path, sys_dev_path, PATH_MAX);
+	strncat(sys_scsi_host_dir_path, iscsi_host_dir_str,
+		PATH_MAX - iscsi_host_dir_strlen);
 
 	n = scandir(sys_scsi_host_dir_path, &namelist, _scan_filter_skip_dot,
 		    alphasort);

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1153,7 +1153,7 @@ int iscsi_sysfs_for_each_iface_on_host(void *data, uint32_t host_no,
 	int rc = 0, i, n;
 	struct iface_rec iface;
         char devpath[PATH_SIZE];
-        char sysfs_path[PATH_SIZE];
+        char sysfs_dev_iscsi_iface_path[PATH_SIZE];
         char id[NAME_SIZE];
 
         snprintf(id, sizeof(id), "host%u", host_no);
@@ -1163,11 +1163,11 @@ int iscsi_sysfs_for_each_iface_on_host(void *data, uint32_t host_no,
                 return ISCSI_ERR_SYSFS_LOOKUP;
         }
 
-	sprintf(sysfs_path, "/sys");
-	strlcat(sysfs_path, devpath, sizeof(sysfs_path));
-	strlcat(sysfs_path, "/iscsi_iface", sizeof(sysfs_path));
+	sprintf(sysfs_dev_iscsi_iface_path, "/sys");
+	strlcat(sysfs_dev_iscsi_iface_path, devpath, sizeof(sysfs_dev_iscsi_iface_path));
+	strlcat(sysfs_dev_iscsi_iface_path, "/iscsi_iface", sizeof(sysfs_dev_iscsi_iface_path));
 
-	n = scandir(sysfs_path, &namelist, trans_filter, alphasort);
+	n = scandir(sysfs_dev_iscsi_iface_path, &namelist, trans_filter, alphasort);
 	if (n <= 0)
 		/* older kernels or some drivers will not have ifaces */
 		return 0;

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1806,7 +1806,7 @@ int iscsi_sysfs_for_each_device(void *data, int host_no, uint32_t sid,
 	int h, b, t, l, i, n, err = 0, target;
 	char devpath[PATH_SIZE];
 	char id[NAME_SIZE];
-	char path_full[PATH_SIZE];
+	char path_full[3*PATH_SIZE];
 
 	target = get_target_no_from_sid(sid, &err);
 	if (err)
@@ -1821,6 +1821,13 @@ int iscsi_sysfs_for_each_device(void *data, int host_no, uint32_t sid,
 
 	snprintf(path_full, sizeof(path_full), "%s%s/device/target%d:0:%d",
 		 sysfs_path, devpath, host_no, target);
+
+	if (strlen(path_full) > PATH_SIZE) {
+		log_debug(3, "Could not lookup devpath for %s %s (too long)",
+			  ISCSI_SESSION_SUBSYS, id);
+		return ISCSI_ERR_SYSFS_LOOKUP;
+	}
+
 	n = scandir(path_full, &namelist, trans_filter,
 		    alphasort);
 	if (n <= 0)


### PR DESCRIPTION
The SUSE build service is trying to phase in use of gcc-8, and doing so has found a few small string-handling "bugs" (more like nits) in the open-iscsi code. This fixes all of them as well as fixing a local variable which had an unfortunate name so was hiding a global variable. No functional changes.