### PR TITLE
Add error message for new ISCSI_ERR_NOP_TIMEDOUT

### DIFF
--- a/usr/kern_err_table.c
+++ b/usr/kern_err_table.c
@@ -77,6 +77,8 @@ const char *kern_err_code_to_string(int err)
 	case ISCSI_ERR_SCSI_EH_SESSION_RST:
 		return "ISCSI_ERR_SCSI_EH_SESSION_RST: Session was dropped as "
 			"a result of SCSI error recovery";
+	case ISCSI_ERR_NOP_TIMEDOUT:
+		return "ISCSI_ERR_NOP_TIMEDOUT: A NOP has timed out";
 	default:
 		return "Invalid or unknown error code";
 	}


### PR DESCRIPTION
This new error enum was added with commit 5c654fcc617a,
but it needs to be added to kern_err_table as well.