### PR TITLE
Allow a host_id value of zero.

### DIFF
--- a/libopeniscsiusr/iface.c
+++ b/libopeniscsiusr/iface.c
@@ -111,7 +111,6 @@ int _iscsi_iface_get_from_sysfs(struct iscsi_context *ctx, uint32_t host_id,
 	bool matched = false;
 
 	assert(ctx != NULL);
-	assert(host_id != 0);
 	assert(iface != NULL);
 
 	*iface = NULL;


### PR DESCRIPTION
In libopeniscsiusr, when getting iface from
sysfs, allow a host_id of zero, since the
host_id starts at zero. The fact that it
is a uint32_t is enough of a limitation.