### PR TITLE
Libopeniscsiusr fixes

### DIFF
--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -822,7 +822,7 @@ int _idbm_iface_get(struct iscsi_context *ctx, const char *iface_name, struct
 		    iscsi_iface **iface)
 {
 	int rc = LIBISCSI_OK;
-	char conf_path[PATH_MAX];
+	char *conf_path = NULL;
 	struct idbm_rec *recs = NULL;
 
 	assert(iface != NULL);
@@ -833,7 +833,8 @@ int _idbm_iface_get(struct iscsi_context *ctx, const char *iface_name, struct
 	if (iface_name == NULL)
 		goto out;
 
-	snprintf(conf_path, PATH_MAX, "%s/%s", IFACE_CONFIG_DIR, iface_name);
+	_good(_asprintf(&conf_path, "%s/%s", IFACE_CONFIG_DIR, iface_name),
+	      rc, out);
 
 	*iface = calloc(1, sizeof(struct iscsi_iface));
 	_alloc_null_check(ctx, *iface, rc, out);
@@ -864,6 +865,7 @@ out:
 		iscsi_iface_free(*iface);
 		*iface = NULL;
 	}
+	free(conf_path);
 	_idbm_recs_free(recs);
 	return rc;
 }
@@ -1023,7 +1025,7 @@ int _idbm_node_get(struct iscsi_context *ctx, const char *target_name,
 		   struct iscsi_node **node)
 {
 	int rc = LIBISCSI_OK;
-	char conf_path[PATH_MAX];
+	char *conf_path = NULL;
 	struct idbm_rec *recs = NULL;
 
 	assert(node != NULL);
@@ -1035,11 +1037,11 @@ int _idbm_node_get(struct iscsi_context *ctx, const char *target_name,
 		goto out;
 
 	if (iface_name == NULL)			// old style of config
-		snprintf(conf_path, PATH_MAX, "%s/%s/%s", NODE_CONFIG_DIR,
-			 target_name, portal);
+		_good(_asprintf(&conf_path, "%s/%s/%s", NODE_CONFIG_DIR,
+			 target_name, portal), rc, out);
 	else
-		snprintf(conf_path, PATH_MAX, "%s/%s/%s/%s", NODE_CONFIG_DIR,
-			 target_name, portal, iface_name);
+		_good(_asprintf(&conf_path, "%s/%s/%s/%s", NODE_CONFIG_DIR,
+			 target_name, portal, iface_name), rc, out);
 
 	*node = calloc(1, sizeof(struct iscsi_node));
 	_alloc_null_check(ctx, *node, rc, out);
@@ -1083,6 +1085,7 @@ out:
 		iscsi_node_free(*node);
 		*node = NULL;
 	}
+	free(conf_path);
 	_idbm_recs_free(recs);
 	return rc;
 }

--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -841,6 +841,9 @@ int _idbm_iface_get(struct iscsi_context *ctx, const char *iface_name, struct
 	snprintf((*iface)->name, sizeof((*iface)->name)/sizeof(char),
 		 "%s", iface_name);
 
+	if (strstr(iface_name, "ipv6"))
+		(*iface)->is_ipv6 = true;
+
 	recs = _idbm_recs_alloc();
 	_alloc_null_check(ctx, recs, rc, out);
 

--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -370,6 +370,8 @@ static int _idbm_iface_rec_link(struct iscsi_iface *iface,
 		 _CAN_MODIFY);
 	_rec_str(IFACE_IPADDR, recs, iface, ipaddress, IDBM_SHOW, num,
 		 _CAN_MODIFY);
+	_rec_uint8(IFACE_PREFIX_LEN, recs, iface, prefix_len, IDBM_SHOW, num,
+		_CAN_MODIFY);
 	_rec_str(IFACE_HWADDR, recs, iface, hwaddress, IDBM_SHOW, num,
 		 _CAN_MODIFY);
 	_rec_str(IFACE_TRANSPORTNAME, recs, iface, transport_name, IDBM_SHOW,

--- a/libopeniscsiusr/idbm_fields.h
+++ b/libopeniscsiusr/idbm_fields.h
@@ -29,6 +29,7 @@
 #define IFACE_ISID		"iface.isid"
 #define IFACE_BOOT_PROTO	"iface.bootproto"
 #define IFACE_IPADDR		"iface.ipaddress"
+#define IFACE_PREFIX_LEN	"iface.prefix_len"
 #define IFACE_SUBNET_MASK	"iface.subnet_mask"
 #define IFACE_GATEWAY		"iface.gateway"
 #define IFACE_PRIMARY_DNS	"iface.primary_dns"

--- a/libopeniscsiusr/iface.h
+++ b/libopeniscsiusr/iface.h
@@ -57,9 +57,13 @@ struct iscsi_iface {
 	char			ipv6_autocfg[NI_MAXHOST];
 	char			linklocal_autocfg[NI_MAXHOST];
 	char			router_autocfg[NI_MAXHOST];
-//	uint8_t			prefix_len;
+	uint8_t			prefix_len;
 	/* ^ prefix_len is removed, as linux kernel has no such sysfs property
 	 * and there is no actual code in usr/ folder set this property
+	 *
+	 * Added back, we need to be backward compatible with iface records
+	 * created by older tools. Look at fixing code to ignore in record
+	 * files instead? - cleech
 	 */
 	uint16_t		vlan_id;
 	uint8_t			vlan_priority;

--- a/libopeniscsiusr/iface.h
+++ b/libopeniscsiusr/iface.h
@@ -139,6 +139,7 @@ struct iscsi_iface {
 
 __DLL_LOCAL int _iscsi_iface_get_from_sysfs(struct iscsi_context *ctx,
 					    uint32_t host_id, uint32_t sid,
+					    char *iface_kern_id,
 					    struct iscsi_iface **iface);
 
 __DLL_LOCAL bool _iface_is_valid(struct iscsi_iface *iface);

--- a/libopeniscsiusr/misc.h
+++ b/libopeniscsiusr/misc.h
@@ -35,6 +35,9 @@
 			goto out; \
 	} while(0)
 
+#define _asprintf(...) \
+	(asprintf(__VA_ARGS__) == -1 ? LIBISCSI_ERR_NOMEM : LIBISCSI_OK)
+
 __DLL_LOCAL void _iscsi_log(struct iscsi_context *ctx, int priority,
 			    const char *file, int line, const char *func_name,
 			    const char *format, ...);

--- a/libopeniscsiusr/misc.h
+++ b/libopeniscsiusr/misc.h
@@ -87,10 +87,15 @@ __DLL_LOCAL void _iscsi_log_stderr(struct iscsi_context *ctx, int priority,
 #define _strerror(err_no, buff) \
 	strerror_r(err_no, buff, _STRERR_BUFF_LEN)
 
+/* Workaround for suppress GCC 8 `stringop-truncation` warnings. */
 #define _strncpy(dst, src, size) \
 	do { \
-		strncpy(dst, src, size); \
-		* (char *) (dst + (size - 1)) = '\0'; \
+		memcpy(dst, src, \
+		       (size_t) size > strlen(src) ? \
+		       strlen(src) : (size_t) size); \
+		* (char *) (dst + \
+			    ((size_t) size - 1 > strlen(src) ? \
+			     strlen(src) : (size_t) (size - 1))) = '\0'; \
 	} while(0)
 
 __DLL_LOCAL int _scan_filter_skip_dot(const struct dirent *dir);

--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -229,7 +229,8 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 
 	_good(_iscsi_host_id_of_session(ctx, sid, &host_id), rc, out);
 
-	_good(_iscsi_iface_get_from_sysfs(ctx, host_id, sid, &((*se)->iface)),
+	/* does this need to the correct iface_kern_id for the session? */
+	_good(_iscsi_iface_get_from_sysfs(ctx, host_id, sid, NULL, &((*se)->iface)),
 	      rc, out);
 
 out:

--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -105,8 +105,8 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 		      struct iscsi_session **se)
 {
 	int rc = LIBISCSI_OK;
-	char sysfs_se_dir_path[PATH_MAX];
-	char sysfs_con_dir_path[PATH_MAX];
+	char *sysfs_se_dir_path = NULL;
+	char *sysfs_con_dir_path = NULL;
 	uint32_t host_id = 0;
 
 	assert(ctx != NULL);
@@ -114,17 +114,16 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 
 	_debug(ctx, "Querying iSCSI session for sid %" PRIu32, sid);
 
-	snprintf(sysfs_se_dir_path, PATH_MAX, "%s/session%" PRIu32,
-		 _ISCSI_SYS_SESSION_DIR, sid);
-	snprintf(sysfs_con_dir_path, PATH_MAX, "%s/connection%" PRIu32 ":0",
-		 _ISCSI_SYS_CONNECTION_DIR, sid);
+	_good(_asprintf(&sysfs_se_dir_path, "%s/session%" PRIu32,
+			_ISCSI_SYS_SESSION_DIR, sid), rc, out);
+	_good(_asprintf(&sysfs_con_dir_path, "%s/connection%" PRIu32 ":0",
+			_ISCSI_SYS_CONNECTION_DIR, sid), rc, out);
 	/* ^ BUG(Gris Ge): ':0' here in kernel is referred as connection id.
 	 *		   but the open-iscsi assuming it's always 0, need
 	 *		   investigation.
 	 */
 
-	*se = (struct iscsi_session *)
-		calloc(sizeof(struct iscsi_session), 1);
+	*se = (struct iscsi_session *) calloc(1, sizeof(struct iscsi_session));
 	_alloc_null_check(ctx, *se , rc, out);
 
 	if (! _file_exists(sysfs_se_dir_path)) {
@@ -238,6 +237,8 @@ out:
 		iscsi_session_free(*se);
 		*se = NULL;
 	}
+	free(sysfs_se_dir_path);
+	free(sysfs_con_dir_path);
 	return rc;
 }
 

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -229,6 +229,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 		}
 	}
 
+	errno = 0;
 	tmp_val = strtoll((const char *) buff, NULL, 10 /* base */);
 	errno_save = errno;
 	if ((errno_save != 0) && (! ignore_error)) {

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -17,6 +17,10 @@
  * Author: Gris Ge <fge@redhat.com>
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -73,19 +77,16 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 				   bool ignore_error);
 
 /*
- * dev_path should be char[PATH_MAX]
+ * dev_path needs to be freed by the caller on success
  */
 static int sysfs_get_dev_path(struct iscsi_context *ctx, const char *path,
-			      enum _sysfs_dev_class class, char *dev_path);
+			      enum _sysfs_dev_class class, char **dev_path);
 
 _sysfs_prop_get_int_func_gen(_sysfs_prop_get_u8, uint8_t, UINT8_MAX);
 _sysfs_prop_get_int_func_gen(_sysfs_prop_get_u16, uint16_t, UINT16_MAX);
 _sysfs_prop_get_int_func_gen(_sysfs_prop_get_i32, int32_t, INT32_MAX);
 _sysfs_prop_get_int_func_gen(_sysfs_prop_get_u32, uint32_t, UINT32_MAX);
 
-/*
- * dev_path should be char[PATH_MAX].
- */
 static int sysfs_read_file(const char *path, uint8_t *buff, size_t buff_size)
 {
 	int fd = -1;
@@ -130,7 +131,7 @@ int _sysfs_prop_get_str(struct iscsi_context *ctx, const char *dir_path,
 			const char *prop_name, char *buff, size_t buff_size,
 			const char *default_value)
 {
-	char file_path[PATH_MAX];
+	char *file_path = NULL;
 	int rc = LIBISCSI_OK;
 	int errno_save = 0;
 
@@ -138,7 +139,7 @@ int _sysfs_prop_get_str(struct iscsi_context *ctx, const char *dir_path,
 	assert(prop_name != NULL);
 	assert(buff != NULL);
 
-	snprintf(file_path, PATH_MAX, "%s/%s", dir_path, prop_name);
+	_good(_asprintf(&file_path, "%s/%s", dir_path, prop_name), rc, out);
 
 	errno_save = sysfs_read_file(file_path, (uint8_t *) buff, buff_size);
 	if (errno_save != 0) {
@@ -176,6 +177,8 @@ int _sysfs_prop_get_str(struct iscsi_context *ctx, const char *dir_path,
 		} else
 			_debug(ctx, "Open '%s', got '%s'", file_path, buff);
 	}
+out:
+	free(file_path);
 	return rc;
 }
 
@@ -184,7 +187,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 				 long long int *val,
 				 long long int default_value, bool ignore_error)
 {
-	char file_path[PATH_MAX];
+	char *file_path = NULL;
 	int rc = LIBISCSI_OK;
 	int errno_save = 0;
 	uint8_t buff[_INT32_STR_MAX_LEN];
@@ -196,7 +199,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 
 	*val = 0;
 
-	snprintf(file_path, PATH_MAX, "%s/%s", dir_path, prop_name);
+	_good(_asprintf(&file_path, "%s/%s", dir_path, prop_name), rc, out);
 
 	errno_save = sysfs_read_file(file_path, buff, _INT32_STR_MAX_LEN);
 	if (errno_save != 0) {
@@ -206,7 +209,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 				_error(ctx, "Failed to read '%s': "
 				       "file '%s' does not exists",
 				       prop_name, file_path);
-				return rc;
+				goto out;
 			} else {
 				_info(ctx,
 				       "Failed to read '%s': "
@@ -214,18 +217,18 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 				      "default value %lld",
 				      file_path, default_value);
 				*val = default_value;
-				return rc;
+				goto out;
 			}
 		} else if (errno_save == EACCES) {
 			rc = LIBISCSI_ERR_ACCESS;
 			_error(ctx, "Permission deny when reading '%s'",
 			       file_path);
-			return rc;
+			goto out;
 		} else {
 			rc = LIBISCSI_ERR_BUG;
 			_error(ctx, "Error when reading '%s': %d", file_path,
 			       errno_save);
-			return rc;
+			goto out;
 		}
 	}
 
@@ -236,18 +239,19 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 		rc = LIBISCSI_ERR_BUG;
 		_error(ctx, "Sysfs: %s: Error when converting '%s' "
 		       "to number", file_path,  (char *) buff, errno_save);
-		return rc;
+		goto out;
 	}
 
 	*val = tmp_val;
 
 	_debug(ctx, "Open '%s', got %lld", file_path, tmp_val);
-
+out:
+	free(file_path);
 	return rc;
 }
 
 static int sysfs_get_dev_path(struct iscsi_context *ctx, const char *path,
-			      enum _sysfs_dev_class class, char *dev_path)
+			      enum _sysfs_dev_class class, char **dev_path)
 {
 	int rc = LIBISCSI_OK;
 	int errno_save = 0;
@@ -260,9 +264,8 @@ static int sysfs_get_dev_path(struct iscsi_context *ctx, const char *path,
 	assert(path != NULL);
 	assert(dev_path != NULL);
 
-	memset(dev_path, 0, PATH_MAX);
-
-	if (realpath(path, dev_path) == NULL) {
+	*dev_path = realpath(path, NULL);
+	if (*dev_path == NULL) {
 		errno_save = errno;
 		rc = LIBISCSI_ERR_SYSFS_LOOKUP;
 		_error(ctx, "realpath() failed on %s with error %d", path,
@@ -297,22 +300,24 @@ static int sysfs_get_dev_path(struct iscsi_context *ctx, const char *path,
 		goto out;
 	}
 	need_free_reg = 1;
-	if (regexec(&regex, dev_path, 2 /* count of max matches */,
+	if (regexec(&regex, *dev_path, 2 /* count of max matches */,
 		    reg_match, 0 /* no flags */) != 0) {
 		rc = LIBISCSI_ERR_SYSFS_LOOKUP;
-		_error(ctx, "regexec() not match for %s", dev_path);
+		_error(ctx, "regexec() not match for %s", *dev_path);
 		goto out;
 	}
 
-	*(dev_path + reg_match[1].rm_eo ) = '\0';
+	*(*dev_path + reg_match[1].rm_eo ) = '\0';
 
-	_debug(ctx, "Got dev path of '%s': '%s'", path, dev_path);
+	_debug(ctx, "Got dev path of '%s': '%s'", path, *dev_path);
 
 out:
 	if (need_free_reg)
 		regfree(&regex);
-	if (rc != LIBISCSI_OK)
-		memset(dev_path, 0, PATH_MAX);
+	if (rc != LIBISCSI_OK) {
+		free(*dev_path);
+		*dev_path = NULL;
+	}
 	return rc;
 }
 
@@ -320,38 +325,29 @@ int _iscsi_host_id_of_session(struct iscsi_context *ctx, uint32_t sid,
 			      uint32_t *host_id)
 {
 	int rc = LIBISCSI_OK;
-	char sys_se_dir_path[PATH_MAX];
-	char sys_dev_path[PATH_MAX];
-	char sys_scsi_host_dir_path[PATH_MAX];
+	char *sys_se_dir_path = NULL;
+	char *sys_dev_path = NULL;
+	char *sys_scsi_host_dir_path = NULL;
 	struct dirent **namelist = NULL;
 	int n = 0;
 	const char *host_id_str = NULL;
 	const char iscsi_host_dir_str[] = "/iscsi_host/";
-	const unsigned int iscsi_host_dir_strlen = strlen(iscsi_host_dir_str);
 
 	assert(ctx != NULL);
 	assert(sid != 0);
 	assert(host_id != NULL);
 
-	snprintf(sys_se_dir_path, PATH_MAX, "%s/session%" PRIu32,
-		 _ISCSI_SYS_SESSION_DIR, sid);
+	_good(_asprintf(&sys_se_dir_path, "%s/session%" PRIu32,
+			_ISCSI_SYS_SESSION_DIR, sid), rc, out);
 
 	*host_id = 0;
 
 	_good(sysfs_get_dev_path(ctx, sys_se_dir_path,
-				 _SYSFS_DEV_CLASS_ISCSI_SESSION, sys_dev_path),
+				 _SYSFS_DEV_CLASS_ISCSI_SESSION, &sys_dev_path),
 	      rc, out);
 
-	if ((strlen(sys_dev_path) + iscsi_host_dir_strlen) >= PATH_MAX) {
-		rc = LIBISCSI_ERR_SYSFS_LOOKUP;
-		_error(ctx, "Pathname too long: %s%s",
-		       sys_dev_path, iscsi_host_dir_str);
-		goto out;
-	}
-
-	strncpy(sys_scsi_host_dir_path, sys_dev_path, PATH_MAX);
-	strncat(sys_scsi_host_dir_path, iscsi_host_dir_str,
-		PATH_MAX - iscsi_host_dir_strlen);
+	_good(_asprintf(&sys_scsi_host_dir_path, "%s%s",
+			sys_dev_path, iscsi_host_dir_str), rc, out);
 
 	_good(_scandir(ctx, sys_scsi_host_dir_path, &namelist, &n), rc, out);
 
@@ -371,7 +367,9 @@ int _iscsi_host_id_of_session(struct iscsi_context *ctx, uint32_t sid,
 
 out:
 	_scandir_free(namelist, n);
-
+	free(sys_se_dir_path);
+	free(sys_dev_path);
+	free(sys_scsi_host_dir_path);
 	return rc;
 }
 
@@ -441,17 +439,21 @@ int _iscsi_hids_get(struct iscsi_context *ctx, uint32_t **hids,
 
 bool _iscsi_transport_is_loaded(const char *transport_name)
 {
-	char path[PATH_MAX];
+	int rc = LIBISCSI_OK;
+	char *path = NULL;
 
 	if (transport_name == NULL)
 		return false;
 
-	snprintf(path, PATH_MAX, "%s/%s", _ISCSI_SYS_TRANSPORT_DIR,
-		 transport_name);
+	_good(_asprintf(&path, "%s/%s", _ISCSI_SYS_TRANSPORT_DIR,
+			transport_name), rc, out);
 
-	if (access(path, F_OK) == 0)
+	if (access(path, F_OK) == 0) {
+		free(path);
 		return true;
-
+	}
+out:
+	free(path);
 	return false;
 }
 
@@ -468,23 +470,15 @@ int _iscsi_iface_kern_ids_of_host_id(struct iscsi_context *ctx,
 	int n = 0;
 	uint32_t i = 0;
 
-	sysfs_sh_path = malloc(PATH_MAX);
-	_alloc_null_check(ctx, sysfs_sh_path, rc, out);
-
-	dev_path = malloc(PATH_MAX);
-	_alloc_null_check(ctx, dev_path, rc, out);
-
-	sysfs_iface_path = malloc(PATH_MAX);
-	_alloc_null_check(ctx, sysfs_iface_path, rc, out);
-
-	snprintf(sysfs_sh_path, PATH_MAX, "%s/host%" PRIu32,
-		 _ISCSI_SYS_HOST_DIR, host_id);
+	_good(_asprintf(&sysfs_sh_path, "%s/host%" PRIu32,
+			_ISCSI_SYS_HOST_DIR, host_id), rc, out);
 
 	_good(sysfs_get_dev_path(ctx, sysfs_sh_path,
-				 _SYSFS_DEV_CLASS_ISCSI_HOST, dev_path),
+				 _SYSFS_DEV_CLASS_ISCSI_HOST, &dev_path),
 	      rc, out);
 
-	snprintf(sysfs_iface_path, PATH_MAX, "%s/iscsi_iface", dev_path);
+	_good(_asprintf(&sysfs_iface_path, "%s/iscsi_iface", dev_path),
+	      rc, out);
 
 	_good(_scandir(ctx, sysfs_iface_path, &namelist, &n), rc, out);
 

--- a/libopeniscsiusr/sysfs.h
+++ b/libopeniscsiusr/sysfs.h
@@ -67,11 +67,13 @@ __DLL_LOCAL int _iscsi_host_id_of_session(struct iscsi_context *ctx,
 					  uint32_t sid, uint32_t *host_id);
 
 /*
- * iface_kern_id should be char[PATH_MAX]
+ * iface_kern_id returns an allocated (char *)[iface_count]
+ * that needs to be freed by the caller
  */
-__DLL_LOCAL int _iscsi_iface_kern_id_of_host_id(struct iscsi_context *ctx,
-						uint32_t host_id,
-						char *iface_kern_id);
+__DLL_LOCAL int _iscsi_iface_kern_ids_of_host_id(struct iscsi_context *ctx,
+						 uint32_t host_id,
+						 char ***iface_kern_ids,
+						 uint32_t *iface_count);
 
 /*
  * The memory of (uint32_t *sids) should be freed by free().


### PR DESCRIPTION
Fixes for iface handling regressions after merging the libopeniscsiusr code.
Found while testing under a variety of iSCSI HBAs (be2iscsi, qla4xxx, bnx2i, qedi)