### PR TITLE
libopeniscsiusr: Fix compile error on GCC 8.

### DIFF
--- a/libopeniscsiusr/iface.c
+++ b/libopeniscsiusr/iface.c
@@ -487,9 +487,9 @@ static int _fill_hw_iface_from_sys(struct iscsi_context *ctx,
 	assert(iface != NULL);
 	assert(iface_kern_id != NULL);
 
-	sysfs_iface_dir_path = malloc(PATH_MAX);
+	sysfs_iface_dir_path = malloc(PATH_MAX * 2);
 	_alloc_null_check(ctx, sysfs_iface_dir_path, rc, out);
-	snprintf(sysfs_iface_dir_path, PATH_MAX, "%s/%s",
+	snprintf(sysfs_iface_dir_path, PATH_MAX * 2, "%s/%s",
 		 _ISCSI_SYS_IFACE_DIR, iface_kern_id);
 
 	_good(_sysfs_prop_get_str(ctx, sysfs_iface_dir_path,

--- a/libopeniscsiusr/misc.h
+++ b/libopeniscsiusr/misc.h
@@ -84,10 +84,15 @@ __DLL_LOCAL void _iscsi_log_stderr(struct iscsi_context *ctx, int priority,
 #define _strerror(err_no, buff) \
 	strerror_r(err_no, buff, _STRERR_BUFF_LEN)
 
+/* Workaround for suppress GCC 8 `stringop-truncation` warnings. */
 #define _strncpy(dst, src, size) \
 	do { \
-		strncpy(dst, src, size); \
-		* (char *) (dst + (size - 1)) = '\0'; \
+		memcpy(dst, src, \
+		       (size_t) size > strlen(src) ? \
+		       strlen(src) : (size_t) size); \
+		* (char *) (dst + \
+			    ((size_t) size - 1 > strlen(src) ? \
+			     strlen(src) : (size_t) (size - 1))) = '\0'; \
 	} while(0)
 
 __DLL_LOCAL int _scan_filter_skip_dot(const struct dirent *dir);


### PR DESCRIPTION
Fix two compile warnings(will be treated as error):
 * `strncpy` for stringop-truncation warning:
  Use memcpy instead and manually add trailing '\0'.
 * `snprintf` for format-truncation warning:
  Double the buffer size.