### PR TITLE
iscsiuio: Add inter-host mutex while doing xmit

### DIFF
--- a/iscsiuio/src/unix/libs/cnic.c
+++ b/iscsiuio/src/unix/libs/cnic.c
@@ -103,6 +103,8 @@ static int cnic_arp_send(nic_t *nic, nic_interface_t *nic_iface, int fd,
 	static const uint8_t multicast_mac[] = {
 				0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
+	LOG_DEBUG(PFX "%s: host:%d - try getting xmit mutex cnic arp send",
+		  nic->log_name, nic->host_no);
 	rc = pthread_mutex_trylock(&nic->xmit_mutex);
 	if (rc != 0) {
 		LOG_DEBUG(PFX "%s: could not get xmit_mutex", nic->log_name);

--- a/iscsiuio/src/unix/nic_utils.c
+++ b/iscsiuio/src/unix/nic_utils.c
@@ -1433,6 +1433,10 @@ nic_interface_t *nic_find_nic_iface(nic_t *nic,
 	nic_interface_t *current_vlan = NULL;
 
 	while (current != NULL) {
+		LOG_DEBUG(PFX "%s: incoming protocol: %d, vlan_id:%d iface_num: %d, request_type: %d",
+			  nic->log_name, protocol, vlan_id, iface_num,  request_type);
+		LOG_DEBUG(PFX "%s: host:%d iface_num: 0x%x VLAN: %d protocol: %d",
+			  nic->log_name, nic->host_no, current->iface_num, current->vlan_id, current->protocol);
 		if (current->protocol != protocol)
 			goto next;
 

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -706,6 +706,11 @@ static int iscsi_sysfs_read_boot(struct iface_rec *iface, char *session)
 		log_debug(5, "could not read %s/%s/subnet", boot_root,
 			  boot_nic);
 
+	if (sysfs_get_str(boot_nic, boot_root, "gateway",
+			  iface->gateway, NI_MAXHOST))
+		log_debug(5, "could not read %s/%s/gateway", boot_root,
+			  boot_nic);
+
 	log_debug(5, "sysfs read boot returns %s/%s/ vlan = %d subnet = %s",
 		  boot_root, boot_nic, iface->vlan_id, iface->subnet_mask);
 	return 0;


### PR DESCRIPTION
This avoids the netlink buffer corruption when more than one host
try to xmit packet at the same time.

Signed-off-by: Manish Rangankar <manish.rangankar@cavium.com>