### PR TITLE
enable MaxOutstandingR2T negotiation

### DIFF
--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -212,6 +212,7 @@ typedef struct iscsi_session {
 	int erl;
 	uint32_t imm_data_en;
 	uint32_t initial_r2t_en;
+	uint32_t max_r2t;
 	uint32_t fast_abort;
 	uint32_t first_burst;
 	uint32_t max_burst;

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -173,6 +173,7 @@ iscsi_copy_operational_params(struct iscsi_conn *conn,
 
 	/* session's operational parameters */
 	session->initial_r2t_en = session_conf->InitialR2T;
+	session->max_r2t = session_conf->MaxOutstandingR2T;
 	session->imm_data_en = session_conf->ImmediateData;
 	session->first_burst = align_32_down(session_conf->FirstBurstLength);
 	/*
@@ -375,7 +376,7 @@ int iscsi_session_set_neg_params(struct iscsi_conn *conn)
 			.conn_only = 0,
 		}, {
 			.param = ISCSI_PARAM_MAX_R2T,
-			.value = &one, /* FIXME: session->max_r2t */
+			.value = &session->max_r2t,
 			.type = ISCSI_INT,
 			.conn_only = 0,
 		}, {

--- a/usr/login.c
+++ b/usr/login.c
@@ -524,14 +524,9 @@ get_op_params_text_keys(iscsi_session_t *session, int cid,
 		text = value_end;
 	} else if (iscsi_find_key_value("MaxOutstandingR2T", text, end, &value,
 					 &value_end)) {
-		if (session->type == ISCSI_SESSION_TYPE_NORMAL) {
-			if (strcmp(value, "1")) {
-				log_error("Login negotiation "
-					       "failed, can't accept Max"
-					       "OutstandingR2T %s", value);
-				return LOGIN_NEGOTIATION_FAILED;
-			}
-		} else
+		if (session->type == ISCSI_SESSION_TYPE_NORMAL)
+			session->max_r2t = strtoul(value, NULL, 0);
+		else
 			session->irrelevant_keys_bitmap |=
 						IRRELEVANT_MAXOUTSTANDINGR2T;
 		text = value_end;
@@ -810,8 +805,9 @@ add_params_normal_session(iscsi_session_t *session, struct iscsi_hdr *pdu,
 		return 0;
 
 	/* these we must have */
+	sprintf(value, "%d", session->max_r2t);
 	if (!iscsi_add_text(pdu, data, max_data_length,
-			    "MaxOutstandingR2T", "1"))
+			    "MaxOutstandingR2T", value))
 		return 0;
 	if (!iscsi_add_text(pdu, data, max_data_length,
 			    "MaxConnections", "1"))


### PR DESCRIPTION
The iscsi_tcp kernel side R2T handling is in libiscsi_tcp and is shared
with at least cxgbi3, and the drivers claim CAP_MULTI_R2T. But the
iscsid login parameter negotiation code never enabled MaxOutstandingR2T.

I've tested this against an LIO target, negotiating to 2 and 4 R2Ts.
The network traces looked good, with the initiator keeping track of
multiple outstanding R2Ts and using the correct next identifier.
Throughput of bulk write data was improved, even over low latency virtio
links.

Signed-off-by: Chris Leech <cleech@redhat.com>