### PR TITLE
context.h: add missing stdarg.h include

### DIFF
--- a/libopeniscsiusr/context.h
+++ b/libopeniscsiusr/context.h
@@ -20,6 +20,7 @@
 #define __ISCSI_USR_CONTEXT_H__
 
 #include "idbm.h"
+#include <stdarg.h>
 
 struct iscsi_context {
 	void (*log_func)(struct iscsi_context *ctx, int priority,


### PR DESCRIPTION
Fix compilation error on uclibc based systems:

```
In file included from idbm.c:59:0:
context.h:27:25: error: unknown type name ‘va_list’
     const char *format, va_list args);
                         ^
<builtin>: recipe for target 'idbm.o' failed
make[1]: *** [idbm.o] Error 1
```