### PR TITLE
iscsiuio: Release xmit_mutex in error code path.

### DIFF
--- a/iscsiuio/src/unix/libs/cnic.c
+++ b/iscsiuio/src/unix/libs/cnic.c
@@ -114,6 +114,7 @@ static int cnic_arp_send(nic_t *nic, nic_interface_t *nic_iface, int fd,
 	eth = (*nic->ops->get_tx_pkt) (nic);
 	if (eth == NULL) {
 		LOG_WARN(PFX "%s: couldn't get tx packet", nic->log_name);
+		pthread_mutex_unlock(&nic->xmit_mutex);
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
This prevents iscsiuio seg fault in case get_tx_pkt fails
while sending ARP.

Signed-off-by: Manish Rangankar <manish.rangankar@cavium.com>