### PR TITLE
Plugging a memory leak from discovery.

### DIFF
--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -1055,6 +1055,11 @@ static void iscsi_destroy_session(struct iscsi_session *session)
 		log_error("Could not safely destroy session %d (err %d)",
 			  session->id, rc);
 done:
+	if (session->target_alias) {
+	    free(session->target_alias);
+	    session->target_alias = NULL;
+	}
+
 	if (conn->socket_fd >= 0) {
 		ipc->ctldev_close();
 		conn->socket_fd = -1;


### PR DESCRIPTION
During discovery the function get_op_params_text_keys()
can allocate a target_alias, but this is never freed.

Discovered-by: zhangzujian.7@gmail.com