### PR TITLE
Cleanup nic nl open usage

### DIFF
--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -393,7 +393,8 @@ int main(int argc, char *argv[])
 		goto error;
 
 	/*  NetLink connection to listen to NETLINK_ISCSI private messages */
-	nic_nl_open();
+	if (nic_nl_open() != 0)
+		goto error;
 
 error:
 	cleanup();

--- a/iscsiuio/src/unix/nic_nl.c
+++ b/iscsiuio/src/unix/nic_nl.c
@@ -534,7 +534,7 @@ static void flush_nic_nl_process_ring(nic_t *nic)
  */
 int nic_nl_open()
 {
-	int rc;
+	int rc = 0;
 	char *msg_type_str;
 
 	/* Prepare the thread to issue the ARP's */
@@ -676,5 +676,5 @@ int nic_nl_open()
 	rc = 0;
 
 error:
-	return 0;
+	return rc;
 }


### PR DESCRIPTION
As discussed in issue #125 there are a few non critical cleanups that could be done.
Due to the way nic_nl_open is currently called from main these changes should not change execution but will help to avoid breaking things later by accident - for example by inserting code in main after the nic_nl_open call.

Fixes #125 