### PR TITLE
Limit iscsid infinite session reconnect attempts at startup using a new config value

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -293,6 +293,12 @@ discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = 32768
 # appropriate number of sessions is created.
 node.session.nr_sessions = 1
 
+# When iscsid starts up it recovers existing sesssions, if possible.
+# If the target has gone away when this occurs, this value
+# limits the number of retries to re-login.
+# Retries are done every 2 seconds.
+node.session.reopen_max = 32
+
 #************
 # Workarounds
 #************

--- a/include/iscsi_err.h
+++ b/include/iscsi_err.h
@@ -68,6 +68,8 @@ enum {
 	ISCSI_ERR_UNKNOWN_DISCOVERY_TYPE = 30,
 	/* child process terminated */
 	ISCSI_ERR_CHILD_TERMINATED	= 31,
+	/* session likely not connected */
+	ISCSI_ERR_SESSION_NOT_CONNECTED = 32,
 
 	/* Always last. Indicates end of error code space */
 	ISCSI_MAX_ERR_VAL,

--- a/libopeniscsiusr/default.c
+++ b/libopeniscsiusr/default.c
@@ -76,7 +76,7 @@ void _default_node(struct iscsi_node *node)
 	node->session.queue_depth = QUEUE_DEPTH;
 	node->session.nr_sessions = 1;
 	node->session.initial_login_retry_max = DEF_INITIAL_LOGIN_RETRIES_MAX;
-	node->session.reopen_max = 32;
+	node->session.reopen_max = DEF_SESSION_REOPEN_MAX;
 	node->session.auth.authmethod = 0;
 	node->session.auth.password_length = 0;
 	node->session.auth.password_in_length = 0;

--- a/libopeniscsiusr/default.h
+++ b/libopeniscsiusr/default.h
@@ -54,6 +54,9 @@
 #define DEF_TGT_RESET_TIMEO		30
 #define DEF_HOST_RESET_TIMEO		60
 
+/* session reopen max retries */
+#define	DEF_SESSION_REOPEN_MAX	32
+
 /* default window size */
 #define TCP_WINDOW_SIZE			(512 * 1024)
 

--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -981,6 +981,8 @@ static void _idbm_node_rec_link(struct iscsi_node *node, struct idbm_rec *recs)
 		   _CAN_MODIFY);
 	_rec_int_o2(SESSION_SCAN, recs, node, session.scan, IDBM_SHOW, "manual",
 		    "auto", num, _CAN_MODIFY);
+	_rec_int64(SESSION_REOPEN_MAX, recs, node, session.reopen_max, IDBM_SHOW, num,
+		   _CAN_MODIFY);
 
 	_rec_str(CONN_ADDR, recs, node, conn.address, IDBM_SHOW, num,
 		 _CANNOT_MODIFY);

--- a/libopeniscsiusr/idbm_fields.h
+++ b/libopeniscsiusr/idbm_fields.h
@@ -136,6 +136,7 @@
 #define SESSION_MAX_R2T		"node.session.iscsi.MaxOutstandingR2T"
 #define SESSION_ERL		"node.session.iscsi.ERL"
 #define SESSION_SCAN		"node.session.scan"
+#define SESSION_REOPEN_MAX	"node.session.reopen_max"
 
 /* connections fields */
 #define CONN_ADDR		"node.conn[0].address"

--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -205,8 +205,8 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 	_sysfs_prop_get_str(ctx, sysfs_con_dir_path, "address", (*se)->address,
 			    sizeof((*se)->address) / sizeof(char), "");
 
-	_good(_sysfs_prop_get_i32(ctx, sysfs_con_dir_path, "port",
-				  &((*se)->port), -1, false), rc, out);
+	_sysfs_prop_get_i32(ctx, sysfs_con_dir_path, "port",
+			    &((*se)->port), -1, true);
 
 	if ((strcmp((*se)->address, "") == 0) &&
 	    (strcmp((*se)->persistent_address, "") != 0))

--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -208,22 +208,20 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 	_sysfs_prop_get_i32(ctx, sysfs_con_dir_path, "port",
 			    &((*se)->port), -1, true);
 
-	if ((strcmp((*se)->address, "") == 0) &&
-	    (strcmp((*se)->persistent_address, "") != 0))
-		_strncpy((*se)->persistent_address, (*se)->address,
-			 sizeof((*se)->persistent_address) / sizeof(char));
-
 	if ((strcmp((*se)->address, "") != 0) &&
 	    (strcmp((*se)->persistent_address, "") == 0))
+		_strncpy((*se)->persistent_address, (*se)->address,
+			 sizeof((*se)->persistent_address) / sizeof(char));
+	else if ((strcmp((*se)->address, "") == 0) &&
+	    (strcmp((*se)->persistent_address, "") != 0))
 		_strncpy((*se)->address, (*se)->persistent_address,
 			 sizeof((*se)->address) / sizeof(char));
 
-	if (((*se)->persistent_port != -1) &&
-	    ((*se)->port == -1))
+	if (((*se)->persistent_port == -1) &&
+	    ((*se)->port != -1))
 		(*se)->persistent_port = (*se)->port;
-
-	if (((*se)->persistent_port != -1) &&
-	    ((*se)->port == -1))
+	else if (((*se)->persistent_port != -1) &&
+		 ((*se)->port == -1))
 		(*se)->port = (*se)->persistent_port;
 
 	_good(_iscsi_host_id_of_session(ctx, sid, &host_id), rc, out);

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -184,6 +184,21 @@ int _sysfs_prop_get_str(struct iscsi_context *ctx, const char *dir_path,
 			_error(ctx, "Failed to read '%s': "
 			       "permission deny when reading '%s'", prop_name,
 			       file_path);
+		} else if (errno_save == ENOTCONN) {
+			if (default_value == NULL) {
+				rc = LIBISCSI_ERR_SYSFS_LOOKUP;
+				_error(ctx, "Failed to read '%s': "
+				       "error when reading '%s': "
+				       "Target unavailable",
+				       prop_name, file_path);
+			} else {
+				_info(ctx, "Failed to read '%s': "
+				       "error when reading '%s': "
+				       "Target unavailable, using default value '%s'",
+				       prop_name, file_path, default_value);
+				memcpy(buff, (void *) default_value,
+				       strlen(default_value) + 1);
+			}
 		} else {
 			rc = LIBISCSI_ERR_BUG;
 			_error(ctx, "Failed to read '%s': "
@@ -246,6 +261,22 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 			_error(ctx, "Permission deny when reading '%s'",
 			       file_path);
 			goto out;
+		} else if (errno_save == ENOTCONN) {
+			if (!ignore_error) {
+				rc = LIBISCSI_ERR_SYSFS_LOOKUP;
+				_error(ctx, "Failed to read '%s': "
+					"error when reading '%s': "
+					"Target unavailable",
+					prop_name, file_path);
+				goto out;
+			} else {
+				_info(ctx, "Failed to read '%s': "
+					"error when reading '%s': "
+					"Target unavailable, using default value %lld",
+					prop_name, file_path, default_value);
+				*val = default_value;
+				goto out;
+			}
 		} else {
 			rc = LIBISCSI_ERR_BUG;
 			_error(ctx, "Error when reading '%s': %d", file_path,

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -47,7 +47,7 @@
 
 #define _SYS_NULL_STR			"(null)"
 
-#define _sysfs_prop_get_int_func_gen(func_name, out_type, type_max_value) \
+#define _sysfs_prop_get_uint_func_gen(func_name, out_type, type_max_value) \
 	int func_name(struct iscsi_context *ctx, const char *dir_path, \
 		      const char *prop_name, out_type *val, \
 		      out_type default_value, bool ignore_error) \
@@ -60,6 +60,28 @@
 					     ignore_error); \
 		if (rc == LIBISCSI_OK) \
 			*val = tmp_val & type_max_value; \
+		return rc; \
+	}
+
+#define _sysfs_prop_get_int_func_gen(func_name, out_type, type_min_value, type_max_value) \
+	int func_name(struct iscsi_context *ctx, const char *dir_path, \
+		      const char *prop_name, out_type *val, \
+		      out_type default_value, bool ignore_error) \
+	{ \
+		long long int tmp_val = 0; \
+		int rc = LIBISCSI_OK; \
+		long long int dv = default_value; \
+		rc = iscsi_sysfs_prop_get_ll(ctx, dir_path, prop_name, \
+					     &tmp_val, (long long int) dv, \
+					     ignore_error); \
+		if (rc == LIBISCSI_OK) { \
+			if (tmp_val > type_max_value) \
+				*val = type_max_value; \
+			else if (tmp_val < type_min_value) \
+				*val = type_min_value; \
+			else \
+				*val = tmp_val; \
+		} \
 		return rc; \
 	}
 
@@ -82,10 +104,10 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 static int sysfs_get_dev_path(struct iscsi_context *ctx, const char *path,
 			      enum _sysfs_dev_class class, char **dev_path);
 
-_sysfs_prop_get_int_func_gen(_sysfs_prop_get_u8, uint8_t, UINT8_MAX);
-_sysfs_prop_get_int_func_gen(_sysfs_prop_get_u16, uint16_t, UINT16_MAX);
-_sysfs_prop_get_int_func_gen(_sysfs_prop_get_i32, int32_t, INT32_MAX);
-_sysfs_prop_get_int_func_gen(_sysfs_prop_get_u32, uint32_t, UINT32_MAX);
+_sysfs_prop_get_uint_func_gen(_sysfs_prop_get_u8, uint8_t, UINT8_MAX);
+_sysfs_prop_get_uint_func_gen(_sysfs_prop_get_u16, uint16_t, UINT16_MAX);
+_sysfs_prop_get_int_func_gen(_sysfs_prop_get_i32, int32_t, INT32_MIN, INT32_MAX);
+_sysfs_prop_get_uint_func_gen(_sysfs_prop_get_u32, uint32_t, UINT32_MAX);
 
 static int sysfs_read_file(const char *path, uint8_t *buff, size_t buff_size)
 {

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -237,7 +237,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 				       "Failed to read '%s': "
 				      "File '%s' does not exists, using ",
 				      "default value %lld",
-				      file_path, default_value);
+				      prop_name, file_path, default_value);
 				*val = default_value;
 				goto out;
 			}

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -468,6 +468,8 @@ idbm_recinfo_node(node_rec_t *r, recinfo_t *ri)
 	__recinfo_int_o2(SESSION_SCAN, ri, r,
 			 session.scan, IDBM_SHOW, "manual", "auto",
 			 num, 1);
+	__recinfo_int(SESSION_REOPEN_MAX, ri, r,
+			session.reopen_max, IDBM_SHOW, num, 1);
 
 	for (i = 0; i < ISCSI_CONN_MAX; i++) {
 		char key[NAME_MAXVAL];
@@ -2978,7 +2980,7 @@ void idbm_node_setup_defaults(node_rec_t *rec)
 	rec->session.queue_depth = QUEUE_DEPTH;
 	rec->session.nr_sessions = 1;
 	rec->session.initial_login_retry_max = DEF_INITIAL_LOGIN_RETRIES_MAX;
-	rec->session.reopen_max = 32;
+	rec->session.reopen_max = DEF_SESSION_REOPEN_MAX;
 	rec->session.auth.authmethod = 0;
 	rec->session.auth.password_length = 0;
 	rec->session.auth.password_in_length = 0;

--- a/usr/idbm_fields.h
+++ b/usr/idbm_fields.h
@@ -46,6 +46,7 @@
 #define SESSION_MAX_R2T		"node.session.iscsi.MaxOutstandingR2T"
 #define SESSION_ERL		"node.session.iscsi.ERL"
 #define SESSION_SCAN		"node.session.scan"
+#define SESSION_REOPEN_MAX	"node.session.reopen_max"
 
 /* connections fields */
 #define CONN_ADDR		"node.conn[%d].address"

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -248,6 +248,7 @@ typedef struct iscsi_session {
 
 	/* connection reopens during recovery */
 	int reopen_cnt;
+	int reopen_max;
 	queue_task_t reopen_qtask;
 	iscsi_session_r_stage_e r_stage;
 	uint32_t replacement_timeout;

--- a/usr/iscsi_err.c
+++ b/usr/iscsi_err.c
@@ -54,6 +54,7 @@ static char *iscsi_err_msgs[] = {
 	/* 29 */ "operation failed but retry may succeed",
 	/* 30 */ "unknown discovery type",
 	/* 31 */ "child process terminated",
+	/* 32 */ "target likely not connected",
 };
 
 char *iscsi_err_to_str(int err)

--- a/usr/iscsi_settings.h
+++ b/usr/iscsi_settings.h
@@ -14,6 +14,9 @@
 #define DEF_TGT_RESET_TIMEO	30
 #define DEF_HOST_RESET_TIMEO	60
 
+/* session reopen max retries */
+#define	DEF_SESSION_REOPEN_MAX	32
+
 /* q depths */
 #define CMDS_MAX	128
 #define QUEUE_DEPTH	32


### PR DESCRIPTION
This set of changes includes some bug fixes for existing problems, but they were problems related to the main issue, so they are fixed as well.

The main issue is that iscsid tries to reconnect "stale" sessions it finds when it starts up, and it does this forever. So we limit that, and we fix up access to the session during that time, as well.