### PR TITLE
When reopen_max=0 retry reopening forever.

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -294,9 +294,10 @@ discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = 32768
 node.session.nr_sessions = 1
 
 # When iscsid starts up it recovers existing sesssions, if possible.
-# If the target has gone away when this occurs, this value
-# limits the number of retries to re-login.
-# Retries are done every 2 seconds.
+# If the target for a session has gone away when this occurs, this
+# configuration value limits the number of retries to re-login, which
+# are done every 2 seconds. A value of 0 implies to retry forever,
+# which is not recommended.
 node.session.reopen_max = 32
 
 #************

--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -733,7 +733,8 @@ static void iscsi_login_eh(struct iscsi_conn *conn, struct queue_task *qtask,
 			log_debug(6, "login failed ISCSI_CONN_STATE_XPT_WAIT/"
 				  "R_STAGE_SESSION_REOPEN (reopen_cnt=%d, reopen_max=%d)",
 				  session->reopen_cnt, session->reopen_max);
-			if (session->reopen_cnt > session->reopen_max) {
+			if (session->reopen_max &&
+			    (session->reopen_cnt > session->reopen_max)) {
 				log_info("Giving up on session %d after %d retries", 
 						session->id, session->reopen_max);
 				session_conn_shutdown(conn, qtask, err);


### PR DESCRIPTION
Commit b9afe4709900 added a configuration variable for session
reconnect called reopen_max that defaults to 32. This changes the
behavior of iscsid on startup if it finds any session information
left over from previous invocations. Adding the option of setting
the retry count to zero to imply previous behavior allows those
that are counting on this behavior to continue. But, make no
mistake, it is recommended not to retry forever, as it leaves
iscsid stuck in "iscsi_sysfs_for_each_session()" in iscsid.c:main(),
so iscsid never fully gets up and running.