### PR TITLE
Make reconnect to session on startup forever default.

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -293,12 +293,16 @@ discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = 32768
 # appropriate number of sessions is created.
 node.session.nr_sessions = 1
 
-# When iscsid starts up it recovers existing sesssions, if possible.
-# If the target for a session has gone away when this occurs, this
-# configuration value limits the number of retries to re-login, which
-# are done every 2 seconds. A value of 0 implies to retry forever,
-# which is not recommended.
-node.session.reopen_max = 32
+# When iscsid starts up it recovers existing sessions, if possible.
+# If the target for a session has gone away when this occurs, the
+# iscsid daemon normally tries to reestablish each session,
+# in succession, in the background, by trying again every two
+# seconds, until all sessions are restored. This configuration
+# variable can limits the number of retries for each session.
+# For example, setting reopen_max=150 would mean that each session
+# recovery was limited to about five minutes.
+# 
+node.session.reopen_max = 0
 
 #************
 # Workarounds

--- a/libopeniscsiusr/default.h
+++ b/libopeniscsiusr/default.h
@@ -55,7 +55,7 @@
 #define DEF_HOST_RESET_TIMEO		60
 
 /* session reopen max retries */
-#define	DEF_SESSION_REOPEN_MAX	32
+#define	DEF_SESSION_REOPEN_MAX		0
 
 /* default window size */
 #define TCP_WINDOW_SIZE			(512 * 1024)

--- a/usr/iscsi_settings.h
+++ b/usr/iscsi_settings.h
@@ -15,7 +15,7 @@
 #define DEF_HOST_RESET_TIMEO	60
 
 /* session reopen max retries */
-#define	DEF_SESSION_REOPEN_MAX	32
+#define	DEF_SESSION_REOPEN_MAX	0
 
 /* q depths */
 #define CMDS_MAX	128


### PR DESCRIPTION
The daemon has traditionally tried to recover stale
sessions, at startup, in serial and in a forked process.
A recent commit, b9afe4709900, added the ability to limit
these retries, and it made the default 32. Commit
467946a945cc added back in the ability to retry forever,
if the retry count was set to 0, but left the default
at 32. This commit changes the default to 0, so as
not to disrupt the expected reconnection behavior by
default.