### PR TITLE
iscsiuio: Do not flush tx queue on each uio interrupt.

### DIFF
--- a/iscsiuio/src/unix/nic.c
+++ b/iscsiuio/src/unix/nic.c
@@ -799,9 +799,12 @@ int nic_process_intr(nic_t *nic, int discard_check)
 
 		nic->intr_count = count;
 
-		LOG_DEBUG(PFX "%s: host:%d - calling clear_tx_intr from process_intr",
-			   nic->log_name, nic->host_no);
-		(*nic->ops->clear_tx_intr) (nic);
+		if (strcmp(nic->ops->description, "qedi")) {
+			LOG_DEBUG(PFX "%s: host:%d - calling clear_tx_intr from process_intr",
+			          nic->log_name, nic->host_no);
+			(*nic->ops->clear_tx_intr) (nic);
+		}
+
 		ret = 1;
 	}
 	pthread_mutex_unlock(&nic->nic_mutex);


### PR DESCRIPTION
Unlike bnx2x, qedi start_xmit netlink provide us guarantee
of transmitting LL2 packet, so there is no need to call clear_tx_intr for
each LL2 packet. This help us in reducing iscsiuio lock contention.

Signed-off-by: Manish Rangankar <manish.rangankar@cavium.com>