### PR TITLE
Use pkg-config in Makefiles for newer libraries.

### DIFF
--- a/libopeniscsiusr/Makefile
+++ b/libopeniscsiusr/Makefile
@@ -23,6 +23,8 @@ endif
 INCLUDE_DIR ?= $(prefix)/include
 PKGCONF_DIR ?= $(LIB_DIR)/pkgconfig
 
+PKG_CONFIG = /usr/bin/pkg-config
+
 LIBISCSI_USR_DIR=$(TOPDIR)/libopeniscsiusr
 
 LIBISCSI_USR_VERSION_MAJOR=0
@@ -43,13 +45,17 @@ OBJS = context.o misc.o session.o sysfs.o iface.o idbm.o node.o default.o
 
 CFLAGS ?= -O2 -g
 CFLAGS += -Wall -Werror -Wextra -fvisibility=hidden -fPIC
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)
+
+LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
 
 LIBADD =
 
 all: $(LIBS) $(LIBS_MAJOR) $(TESTS) doc
 
 $(LIBS): $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname=$@ -o $@ $(OBJS) $(LIBADD)
+	@echo CFLAGS= $(CFLAGS)
+	$(CC) $(CFLAGS) -shared -Wl,-soname=$@ -o $@ $(OBJS) $(LDFLAGS) $(LIBADD)
 	ln -sf $@ $(DEVLIB)
 
 $(LIBS_MAJOR): $(LIBS)

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -32,11 +32,16 @@ IPC_OBJ=ioctl.o
 endif
 endif
 
+PKG_CONFIG = /usr/bin/pkg-config
+
 CFLAGS ?= -O2 -g
 WARNFLAGS ?= -Wall -Wstrict-prototypes
 CFLAGS += $(WARNFLAGS) -I../include -I. -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)
 ISCSI_LIB = -L$(TOPDIR)/libopeniscsiusr -lopeniscsiusr
+LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs libsystemd)
 PROGRAMS = iscsid iscsiadm iscsistart
 
 # libc compat files
@@ -60,14 +65,14 @@ all: $(PROGRAMS)
 
 iscsid: $(ISCSI_LIB_SRCS) $(INITIATOR_SRCS) $(DISCOVERY_SRCS) \
 	iscsid.o session_mgmt.o discoveryd.o mntcheck.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@  -lisns -lcrypto -lrt -lmount $(ISCSI_LIB)
+	$(CC) $(CFLAGS) $^ -o $@  -lisns -lcrypto -lrt -lmount $(LDFLAGS) $(ISCSI_LIB)
 
 iscsiadm: $(ISCSI_LIB_SRCS) $(DISCOVERY_SRCS) iscsiadm.o session_mgmt.o mntcheck.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ -lisns -lcrypto -lmount $(ISCSI_LIB)
+	$(CC) $(CFLAGS) $^ -o $@ -lisns -lcrypto -lmount $(LDFLAGS) $(ISCSI_LIB)
 
 iscsistart: $(ISCSI_LIB_SRCS) $(INITIATOR_SRCS) $(FW_BOOT_SRCS) \
 		iscsistart.o statics.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ -lrt $(ISCSI_LIB)
+	$(CC) $(CFLAGS) $^ -o $@ -lrt $(LDFLAGS) $(ISCSI_LIB)
 clean:
 	rm -f *.o $(PROGRAMS) .depend $(LIBSYS)
 


### PR DESCRIPTION
These two recently-added libraries can be in different
locations on different distros, so use pkg-config to
added the appropriate actions in the make files.