### PR TITLE
Make iscsid.service a requirement.

### DIFF
--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -3,6 +3,7 @@ Description=Login and scanning of iSCSI devices
 Documentation=man:iscsiadm(8) man:iscsid(8)
 Before=remote-fs.target
 After=network.target network-online.target iscsid.service
+Requires=iscsid.service
 ConditionPathExists=/etc/iscsi/initiatorname.iscsi
 
 [Service]


### PR DESCRIPTION
This will ensure daemon is loaded before iscsi.service starts. Also in case daemon fails to load iscsi.service will not be started.