### PR TITLE
Fixed iscsi.service considering every signal and exit code as successful

### DIFF
--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -8,7 +8,7 @@ ConditionPathExists=/etc/iscsi/initiatorname.iscsi
 
 [Service]
 Type=oneshot
-ExecStart=-/sbin/iscsiadm -m node --loginall=automatic
+ExecStart=/sbin/iscsiadm -m node --loginall=automatic
 ExecStop=/sbin/iscsiadm -m node --logoutall=automatic
 ExecStop=/sbin/iscsiadm -m node --logoutall=manual
 SuccessExitStatus=21


### PR DESCRIPTION
Now only code 21 (no objects found to execute on) and normal exit conditions are valid.