### PR TITLE
[WIP] Make systemd optional but enabled by default

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -35,13 +35,18 @@ endif
 PKG_CONFIG = /usr/bin/pkg-config
 
 CFLAGS ?= -O2 -g
+ifdef NO_SYSTEMD
+CFLAGS += -DNO_SYSTEMD
+endif
 WARNFLAGS ?= -Wall -Wstrict-prototypes
 CFLAGS += $(WARNFLAGS) -I../include -I. -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)
 ISCSI_LIB = -L$(TOPDIR)/libopeniscsiusr -lopeniscsiusr
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
+ifndef NO_SYSTEMD
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libsystemd)
+endif
 PROGRAMS = iscsid iscsiadm iscsistart
 
 # libc compat files

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -34,7 +34,10 @@
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#ifndef NO_SYSTEMD
 #include <systemd/sd-daemon.h>
+#endif
 
 #include "iscsid.h"
 #include "mgmt_ipc.h"
@@ -339,6 +342,7 @@ static void missing_iname_warn(char *initiatorname_file)
 /* called right before we enter the event loop */
 static void set_state_to_ready(void)
 {
+#ifndef NO_SYSTEMD
 	if (sessions_to_recover)
 		sd_notify(0, "READY=1\n"
 				"RELOADING=1\n"
@@ -346,14 +350,17 @@ static void set_state_to_ready(void)
 	else
 		sd_notify(0, "READY=1\n"
 				"STATUS=Ready to process requests\n");
+#endif
 }
 
 /* called when recovery process has been reaped */
 static void set_state_done_reloading(void)
 {
+#ifndef NO_SYSTEMD
 	sessions_to_recover = 0;
 	sd_notifyf(0, "READY=1\n"
 			"STATUS=Ready to process requests\n");
+#endif
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This is a WIP work i cooked up in a time to make systemd optional:

- Distros that do not use systemd (like Void Linux and Alpine Linux) can now pass NO_SYSTEMD and the systemd-specific bits will be replaced by no-ops, the systemd/sd-daemon.h include will be removed.
- Distros that use systemd (RHEL/Fedora/OpenSUSE/Arch/Debian/etcetcetc) just do nothing and it will keep going as usual.
