### PR TITLE
Add Restart=on-failure option to iscsid.service

### DIFF
--- a/etc/systemd/iscsid.service
+++ b/etc/systemd/iscsid.service
@@ -10,6 +10,7 @@ Type=notify
 NotifyAccess=main
 ExecStart=/sbin/iscsid -f
 KillMode=mixed
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change adds Restart=on-failure systemd service option to iscsid.service config file so that iscsid daemon is restarted on failure.  This option is particularly useful when using iscsi boot device and iscsid daemon crashes or is inadvertently killed.