### PR TITLE
Fix systemd startup etc

### DIFF
--- a/doc/iscsid.8
+++ b/doc/iscsid.8
@@ -40,7 +40,7 @@ do not write a process ID file.
 .TP
 .BI [-p|--pid=]\fIpid\-file\fP
 write process ID to \fIpid\-file\fR rather than the default
-\fI/var/run/iscsid.pid\fR
+\fI/run/iscsid.pid\fR
 .TP
 .BI [-h|--help]
 display this help and exit

--- a/etc/initd/initd.debian
+++ b/etc/initd/initd.debian
@@ -11,7 +11,7 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/sbin/iscsid
 ADM=/sbin/iscsiadm
-PIDFILE=/var/run/iscsid.pid
+PIDFILE=/run/iscsid.pid
 
 [ -x "$DAEMON" ] || exit 0
 

--- a/etc/initd/initd.redhat
+++ b/etc/initd/initd.redhat
@@ -4,7 +4,7 @@
 # description: Starts and stops the iSCSI initiator
 #
 # processname: iscsid
-# pidfile: /var/run/iscsid.pid
+# pidfile: /run/iscsid.pid
 # config:  /etc/iscsi/iscsid.conf
 
 # Source function library.
@@ -23,7 +23,7 @@ start()
 	echo
 	[ $RETVAL -eq 0 ] || return
 
-	touch /var/lock/subsys/open-iscsi
+	touch /run/lock/subsys/open-iscsi
 
 	echo -n $"Setting up iSCSI targets: "
 	iscsiadm -m node --loginall=automatic
@@ -43,8 +43,8 @@ stop()
 		return $RETVAL
 	fi
 	iscsiadm -k 0
-	rm -f /var/run/iscsid.pid
-	[ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/open-iscsi
+	rm -f /run/iscsid.pid
+	[ $RETVAL -eq 0 ] && rm -f /run/lock/subsys/open-iscsi
 	status=0
 	modprobe -r iscsi_tcp 2>/dev/null
 	if [ "$?" -ne "0" -a "$?" -ne "1" ]; then
@@ -94,7 +94,7 @@ case "$1" in
 			RETVAL=$?
 			;;
 	condrestart)
-			[ -f /var/lock/subsys/open-iscsi ] && restart
+			[ -f /run/lock/subsys/open-iscsi ] && restart
 			;;
 	*)
 			echo $"Usage: $0 {start|stop|restart|status|condrestart}"

--- a/etc/systemd/iscsiuio.service
+++ b/etc/systemd/iscsiuio.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=iSCSI UserSpace I/O driver
+Documentation=man:iscsiuio(8)
+DefaultDependencies=no
+Conflicts=shutdown.target
+Requires=iscsid.service
+BindTo=iscsid.service
+After=network.target
+Before=remote-fs-pre.target iscsid.service
+
+[Service]
+Type=notify
+NotifyAccess=main
+ExecStart=/sbin/iscsiuio -f
+KillMode=mixed
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/iscsiuio.socket
+++ b/etc/systemd/iscsiuio.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Open-iSCSI iscsiuio Socket
+Documentation=man:iscsiuio(8)
+
+[Socket]
+ListenStream=@ISCSID_UIP_ABSTRACT_NAMESPACE
+
+[Install]
+WantedBy=sockets.target

--- a/iscsiuio/docs/iscsiuio.8
+++ b/iscsiuio/docs/iscsiuio.8
@@ -71,7 +71,7 @@ This is to print the version.
 .PP
 .TP
 .BI -p|--pid <pidfile>
-Use pidfile (default  /var/run/iscsiuio.pid )
+Use pidfile (default  /run/iscsiuio.pid )
 .PP
 .TP
 .BI -h|--help

--- a/iscsiuio/src/unix/logger.c
+++ b/iscsiuio/src/unix/logger.c
@@ -135,7 +135,7 @@ int init_logger(char *filename)
 	}
 	main_log.fp = fopen(filename, "a");
 	if (main_log.fp == NULL) {
-		printf("Could not create log file: %s <%s>\n",
+		fprintf(stderr, "WARN: Could not create log file: %s <%s>\n",
 		       filename, strerror(errno));
 		rc = -EIO;
 	}

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -48,6 +48,9 @@
 #include <net/ethernet.h>
 #include <arpa/inet.h>
 #include <sys/mman.h>
+#ifndef	NO_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
 
 #include "uip.h"
 #include "uip_arp.h"
@@ -415,6 +418,11 @@ int main(int argc, char *argv[])
 		write(pipefds[1], "ok\n", 3);
 		close(pipefds[1]);
 	}
+
+#ifndef	NO_SYSTEMD
+	sd_notify(0, "READY=1\n"
+		     "STATUS=Ready to process requests\n");
+#endif
 
 	/*  NetLink connection to listen to NETLINK_ISCSI private messages */
 	if (nic_nl_open() != 0)

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -409,10 +409,12 @@ int main(int argc, char *argv[])
 	if (rc != 0)
 		goto error;
 
-	/* signal parent they can go away now */
-	close(pipefds[0]);
-	write(pipefds[1], "ok\n", 3);
-	close(pipefds[1]);
+	if (!foreground) {
+		/* signal parent they can go away now */
+		close(pipefds[0]);
+		write(pipefds[1], "ok\n", 3);
+		close(pipefds[1]);
+	}
 
 	/*  NetLink connection to listen to NETLINK_ISCSI private messages */
 	if (nic_nl_open() != 0)

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -146,7 +146,7 @@ signal_wait:
 		fini_logger(SHUTDOWN_LOGGER);
 		rc = init_logger(main_log.log_file);
 		if (rc != 0)
-			printf("Could not initialize the logger in "
+			fprintf(stderr, "WARN: Could not initialize the logger in "
 			       "signal!\n");
 		goto signal_wait;
 	default:
@@ -239,6 +239,7 @@ int main(int argc, char *argv[])
 	int foreground = 0;
 	pid_t pid;
 	pthread_attr_t attr;
+	int pipefds[2];
 
 	/*  Record the start time for the user space daemon */
 	opt.start_time = time(NULL);
@@ -281,7 +282,7 @@ int main(int argc, char *argv[])
 		/*  initialize the logger */
 		rc = init_logger(main_log.log_file);
 		if (rc != 0 && opt.debug == DEBUG_ON)
-			printf("WARN: Could not initialize the logger\n");
+			fprintf(stderr, "WARN: Could not initialize the logger\n");
 	}
 
 	LOG_INFO("Started iSCSI uio stack: Ver " PACKAGE_VERSION);
@@ -316,38 +317,53 @@ int main(int argc, char *argv[])
 
 		fd = open(pid_file, O_WRONLY | O_CREAT, 0644);
 		if (fd < 0) {
-			printf("Unable to create pid file: %s", pid_file);
+			fprintf(stderr, "ERR: Unable to create pid file: %s\n",
+				pid_file);
+			exit(1);
+		}
+
+		if (pipe(pipefds) < 0) {
+			fprintf(stderr, "ERR: Unable to create a PIPE: %s\n",
+				strerror(errno));
 			exit(1);
 		}
 
 		pid = fork();
 		if (pid < 0) {
-			printf("Starting daemon failed");
+			fprintf(stderr, "ERR: Starting daemon failed\n");
 			exit(1);
 		} else if (pid) {
+			char msgbuf[4];
+
+			/* parent: wait for child msg then exit */
+			close(pipefds[1]);
+			read(pipefds[0], msgbuf, sizeof(msgbuf));
 			exit(0);
 		}
 
+		/* the child */
 		rc = chdir("/");
 		if (rc == -1)
-			printf("Unable to chdir(\") [%s]", strerror(errno));
+			fprintf(stderr, "WARN: Unable to chdir(\") [%s]\n", strerror(errno));
 
 		if (lockf(fd, F_TLOCK, 0) < 0) {
-			printf("Unable to lock pid file: %s [%s]",
+			fprintf(stderr, "ERR: Unable to lock pid file: %s [%s]\n",
 			       pid_file, strerror(errno));
 			exit(1);
 		}
 
 		rc = ftruncate(fd, 0);
 		if (rc == -1)
-			printf("ftruncate(%d, 0) failed [%s]",
+			fprintf(stderr, "WARN: ftruncate(%d, 0) failed [%s]\n",
 			       fd, strerror(errno));
 
 		sprintf(buf, "%d\n", getpid());
 		written_bytes = write(fd, buf, strlen(buf));
-		if (written_bytes == -1)
-			printf("Could not write pid file [%s]",
+		if (written_bytes == -1) {
+			fprintf(stderr, "ERR: Could not write pid file [%s]\n",
 			       strerror(errno));
+			exit(1);
+		}
 		close(fd);
 
 		daemon_init();
@@ -392,6 +408,11 @@ int main(int argc, char *argv[])
 	rc = iscsid_start();
 	if (rc != 0)
 		goto error;
+
+	/* signal parent they can go away now */
+	close(pipefds[0]);
+	write(pipefds[1], "ok\n", 3);
+	close(pipefds[1]);
 
 	/*  NetLink connection to listen to NETLINK_ISCSI private messages */
 	if (nic_nl_open() != 0)

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -76,7 +76,7 @@
  ******************************************************************************/
 #define PFX "main "
 
-static const char default_pid_filepath[] = "/var/run/iscsiuio.pid";
+static const char default_pid_filepath[] = "/run/iscsiuio.pid";
 
 /*******************************************************************************
  *  Global Variables

--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -93,7 +93,7 @@
 #define ISCSI_END_REC	"# END RECORD"
 
 #ifndef LOCK_DIR
-#define LOCK_DIR		"/var/lock/iscsi"
+#define LOCK_DIR		"/run/lock/iscsi"
 #endif
 #define LOCK_FILE		LOCK_DIR"/lock"
 #define LOCK_WRITE_FILE		LOCK_DIR"/lock.write"

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -38,9 +38,9 @@
 #define CONFIG_FILE		ISCSI_CONFIG_ROOT"iscsid.conf"
 #define INITIATOR_NAME_FILE	ISCSI_CONFIG_ROOT"initiatorname.iscsi"
 
-#define PID_FILE		"/var/run/iscsid.pid"
+#define PID_FILE		"/run/iscsid.pid"
 #ifndef LOCK_DIR
-#define LOCK_DIR		"/var/lock/iscsi"
+#define LOCK_DIR		"/run/lock/iscsi"
 #endif
 #define LOCK_FILE		LOCK_DIR"/lock"
 #define LOCK_WRITE_FILE		LOCK_DIR"/lock.write"


### PR DESCRIPTION
This group of commits brings iscsiuio up to date with iscsid, in that it adds support for systemd at startup time, but in this case it can be ifdefed out, for those cases when systemd is not available.

It also adds example systemd service and socket files for iscsiuio, and it cleans up the error messages in iscsiuio, which didn't all have newlines, and were being dumped to stdout.

Lastly, for those still wishing to use daemon (non-foreground) mode for iscsiuio, I add a handshake between parent and child when becoming a daemon, so that the parent does not exit until the child is actually ready to do business.