### PR TITLE
Fix possible discovery hang when timing out

### DIFF
--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -1355,6 +1355,7 @@ reconnect:
 	if (--session->reopen_cnt < 0) {
 		log_error("connection login retries (reopen_max) %d exceeded",
 			  config->reopen_max);
+		rc = ISCSI_ERR_PDU_TIMEOUT;
 		goto login_failed;
 	}
 


### PR DESCRIPTION
If session reopening failed during discovery, the CPU
could peg at 100% because the code that gives up when
tretires are exhausted was not setting an error
return value.