### PR TITLE
rec update: disable the idbm_lock in read/write when updating the rec

### DIFF
--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -23,6 +23,7 @@
 #define IDBM_H
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include "initiator.h"
 #include "config.h"
@@ -91,22 +92,22 @@ struct user_param {
 };
 
 typedef int (idbm_iface_op_fn)(void *data, node_rec_t *rec);
-typedef int (idbm_portal_op_fn)(int *found,  void *data,
-				char *targetname, int tpgt, char *ip, int port);
+typedef int (idbm_portal_op_fn)(int *found,  void *data, char *targetname,
+				int tpgt, char *ip, int port, bool ruw_lock);
 typedef int (idbm_node_op_fn)(int *found, void *data,
-			      char *targetname);
+			      char *targetname, bool ruw_lock);
 
 struct rec_op_data {
 	void *data;
 	node_rec_t *match_rec;
 	idbm_iface_op_fn *fn;
 };
-extern int idbm_for_each_portal(int *found, void *data,
-				idbm_portal_op_fn *fn, char *targetname);
+extern int idbm_for_each_portal(int *found, void *data, idbm_portal_op_fn *fn,
+				char *targetname, bool ruw_lock);
 extern int idbm_for_each_node(int *found, void *data,
-			      idbm_node_op_fn *fn);
+			      idbm_node_op_fn *fn, bool ruw_lock);
 extern int idbm_for_each_rec(int *found, void *data,
-			     idbm_iface_op_fn *fn);
+			     idbm_iface_op_fn *fn, bool ruw_lock);
 
 
 typedef int (idbm_drec_op_fn)(void *data, discovery_rec_t *drec);
@@ -144,7 +145,7 @@ extern int idbm_discovery_read(discovery_rec_t *rec, int type, char *addr,
 				int port);
 extern int idbm_rec_read(node_rec_t *out_rec, char *target_name,
 			 int tpgt, char *addr, int port,
-			 struct iface_rec *iface);
+			 struct iface_rec *iface, bool disable_lock);
 extern int idbm_node_set_rec_from_param(struct list_head *params,
 					node_rec_t *rec, int verify);
 extern int idbm_node_set_param(void *data, node_rec_t *rec);

--- a/usr/iface.c
+++ b/usr/iface.c
@@ -854,7 +854,7 @@ int iface_print_tree(void *data, struct iface_rec *iface)
 	print_data.match_iface = iface;
 	print_data.last_rec = &last_rec;
 
-	idbm_for_each_rec(&num_found, &print_data, iface_print_nodes);
+	idbm_for_each_rec(&num_found, &print_data, iface_print_nodes, false);
 	return 0;
 }
 

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -237,7 +237,7 @@ static int sync_session(void *data, struct session_info *info)
 
 	if (idbm_rec_read(&rec, info->targetname, info->tpgt,
 			  info->persistent_address, info->persistent_port,
-			  &info->iface)) {
+			  &info->iface, false)) {
 		log_warning("Could not read data from db. Using default and "
 			    "currently negotiated values");
 		setup_rec_from_negotiated_values(&rec, info);


### PR DESCRIPTION
The iscsiadm is getting a file lock while writing out records, and
updates are a read-modify-write operation and currently only the
write is locked.

So the parallel requests are reading in the pre-update record and
then overwriting each other with the writes.

Fixing RHBZ#1624670

Signed-off-by: Xiubo Li <xiubli@redhat.com>