### PR TITLE
The iscsi login/logout service requires iscsid.

### DIFF
--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -5,6 +5,7 @@ Before=remote-fs.target
 After=network.target network-online.target iscsid.service
 Requires=iscsid.service
 ConditionPathExists=/etc/iscsi/initiatorname.iscsi
+Requires=iscsid.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The iscsi.service systemd unit file, which controls
iscsi logins and logouts, should be stopped if the
iscsid service file is stopped.