### PR TITLE
Initialize timeout for printing specific session info.

### DIFF
--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -3948,6 +3948,7 @@ main(int argc, char **argv)
 				rc = ISCSI_ERR_NOMEM;
 				goto out;
 			}
+			info->iscsid_req_tmo = -1;
 
 			rc = iscsi_sysfs_get_sessioninfo_by_id(info, session);
 			if (rc) {


### PR DESCRIPTION
When printing session info from iscsiadm, the following worked:

> # iscsiadm -m session -r N      -- print session info for session N
> # iscsiadm -m session -s        -- print session stats for all sessions

But this did not:

> # iscsiadm -m session -r N -s   -- print session stats for session N

Which is the same as the simple "-s" form if there is just one session.
To fix this error, initialize the timeout to "none" (-1) when sending
our request to iscsi for session stats, as do other requests.