### PR TITLE
setup Travis-CI builds and Coverity scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+compiler: gcc
+os: linux
+dist: bionic
+
+env:
+  global:
+  - secure: kUIw3pil4akjNycH+R2mq8oUszQrt/TCwkQb20oBRXoqsRzYLF6I9VT5wdAERjPsD7BDSiWLxLnisYrdRAs/tQ9h3xvnOJQAX8wKvVF/B883kOwOdI17DkY/dKdzWT+LbojjaXCHZf2yaKVAjibRPO2E8J9zsvpuDLDlon7zD123Amnb/XrSVJH4jefscs1OXFVtaMIKNs7AQPoPK7V9oMZoIbBF5NhYSPpytlf5/VL6ePQlXdd4xAiQR+dg5PvEbMquJh4GvcTo5DzOAJN8L9nGvlGlH5YKxHo7tkOpKFRnCATyenbpVaUBTb/TzA9OsVmxfSr/WrzLLXQxCwfOG6ktZp+1+ANRuL5wLCtDJLooGCw4Wxsicgw69snBoFPWoPW8w4osNQAaGINZnPKM2WSFxq2DBrqHrccGk1lze7upNHikBrwSTgv+SklmZUfcDQjWYxC2owH21BHhVTV6hgNShwS5q9gwWtSWAHc4f34Qvn1gjdV2/791Skk/t4GgTSmt0j0ZVcfsQJaZBvDwkot1yDJ0u/3av+ElMAmCb/9wG3dSqUXv9/V6mAutNb243igIZko6Vmpcosp2bJKXyeVbRkgbMoIfH2VQf9n1sbb01+V9lZsk9usIZZYRcW9Bz6d2H+ooDrM/ha1kQjVqMDP2EyCdBKmQjr8iAi9E4yQ=
+
+addons:
+  apt:
+    update: true
+    packages:
+    - libsystemd-dev
+    - libkmod-dev
+    - libmount-dev
+    - libisns-dev
+    - openssl
+    - flex
+    - bison
+  coverity_scan:
+    project:
+      name: open-iscsi/open-iscsi
+    build_command: make
+    branch_pattern: coverity_scan
+
+before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+
+script: if [ "{COVERITY_SCAN_BRANCH}" != 1 ]; then make; fi


### PR DESCRIPTION
Configure Travis-CI for automated build tests.
Hopefully we can extend this to basic functional as well.

Also sets up Coverity scanning from the Travis build.
Synopsys gives Open Source projects a limited number of free Coverity
scans each day, so this is currently configured to only scan when code
is pushed to a "coverity_scan" branch.