### PR TITLE
configuration support for CHAP algorithms

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -57,6 +57,13 @@ node.leading_login = No
 # to CHAP. The default is None.
 #node.session.auth.authmethod = CHAP
 
+# To configure which CHAP algorithms to enable set
+# node.session.auth.chap_algs to a comma seperated list.
+# The algorithms should be listen with most prefered first.
+# Valid values are MD5, SHA1, SHA256, and SHA3-256.
+# The default is MD5.
+#node.session.auth.chap_algs = SHA3-256,SHA256,SHA1,MD5
+
 # To set a CHAP username and password for initiator
 # authentication by the target(s), uncomment the following lines:
 #node.session.auth.username = username

--- a/libopeniscsiusr/default.c
+++ b/libopeniscsiusr/default.c
@@ -78,6 +78,9 @@ void _default_node(struct iscsi_node *node)
 	node->session.initial_login_retry_max = DEF_INITIAL_LOGIN_RETRIES_MAX;
 	node->session.reopen_max = DEF_SESSION_REOPEN_MAX;
 	node->session.auth.authmethod = 0;
+	/* TYPE_INT_LIST fields should be initialized to ~0 to indicate unset values */
+	memset(node->session.auth.chap_algs, ~0, sizeof(node->session.auth.chap_algs));
+	node->session.auth.chap_algs[0] = ISCSI_AUTH_CHAP_ALG_MD5;
 	node->session.auth.password_length = 0;
 	node->session.auth.password_in_length = 0;
 	node->session.err_tmo.abort_timeout = DEF_ABORT_TIMEO;

--- a/libopeniscsiusr/idbm.h
+++ b/libopeniscsiusr/idbm.h
@@ -48,6 +48,14 @@ enum iscsi_auth_method {
 	ISCSI_AUTH_METHOD_CHAP,
 };
 
+enum iscsi_chap_algs {
+	ISCSI_AUTH_CHAP_ALG_MD5 = 5,
+	ISCSI_AUTH_CHAP_ALG_SHA1 = 6,
+	ISCSI_AUTH_CHAP_ALG_SHA256 = 7,
+	ISCSI_AUTH_CHAP_ALG_SHA3_256 = 8,
+	AUTH_CHAP_ALG_MAX_COUNT = 5,
+};
+
 enum iscsi_startup_type {
 	ISCSI_STARTUP_MANUAL,
 	ISCSI_STARTUP_AUTOMATIC,
@@ -92,6 +100,7 @@ struct iscsi_auth_config {
 	char					username_in[AUTH_STR_MAX_LEN];
 	unsigned char				password_in[AUTH_STR_MAX_LEN];
 	uint32_t				password_in_length;
+	unsigned int				chap_algs[AUTH_CHAP_ALG_MAX_COUNT];
 };
 
 /* all TCP options go in this structure.

--- a/libopeniscsiusr/idbm_fields.h
+++ b/libopeniscsiusr/idbm_fields.h
@@ -120,6 +120,7 @@
 #define SESSION_USERNAME_IN	"node.session.auth.username_in"
 #define SESSION_PASSWORD_IN	"node.session.auth.password_in"
 #define SESSION_PASSWORD_IN_LEN	"node.session.auth.password_in_length"
+#define SESSION_CHAP_ALGS	"node.session.auth.chap_algs"
 #define SESSION_REPLACEMENT_TMO	"node.session.timeo.replacement_timeout"
 #define SESSION_ABORT_TMO	"node.session.err_timeo.abort_timeout"
 #define SESSION_LU_RESET_TMO	"node.session.err_timeo.lu_reset_timeout"

--- a/usr/auth.h
+++ b/usr/auth.h
@@ -271,6 +271,9 @@ extern int acl_send_transit_bit(struct iscsi_acl *client, int *value);
 extern int acl_set_user_name(struct iscsi_acl *client, const char *username);
 extern int acl_set_passwd(struct iscsi_acl *client,
 			  const unsigned char *pw_data, unsigned int pw_len);
+extern int acl_set_chap_alg_list(struct iscsi_acl *client, unsigned int option_count,
+		      const int *option_list);
+extern int acl_init_chap_digests(int *value_list, unsigned int *chap_algs, int count);
 extern int acl_set_auth_rmt(struct iscsi_acl *client, int auth_rmt);
 extern int acl_set_ip_sec(struct iscsi_acl *client, int ip_sec);
 extern int acl_get_dbg_status(struct iscsi_acl *client, int *value);

--- a/usr/config.h
+++ b/usr/config.h
@@ -58,6 +58,7 @@ struct iscsi_auth_config {
 	char username_in[AUTH_STR_MAX_LEN];
 	unsigned char password_in[AUTH_STR_MAX_LEN];
 	unsigned int password_in_length;
+	unsigned int chap_algs[AUTH_CHAP_ALG_MAX_COUNT];
 };
 
 /* all per-connection timeouts go in this structure.

--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -45,6 +45,8 @@
 #define TYPE_UINT8	3
 #define TYPE_UINT16	4
 #define TYPE_UINT32	5
+#define TYPE_INT_LIST	6
+
 #define MAX_KEYS	256   /* number of keys total(including CNX_MAX) */
 #define NAME_MAXVAL	128   /* the maximum length of key name */
 #define VALUE_MAXVAL	256   /* the maximum length of 223 bytes in the RFC. */

--- a/usr/idbm_fields.h
+++ b/usr/idbm_fields.h
@@ -30,6 +30,7 @@
 #define SESSION_USERNAME_IN	"node.session.auth.username_in"
 #define SESSION_PASSWORD_IN	"node.session.auth.password_in"
 #define SESSION_PASSWORD_IN_LEN	"node.session.auth.password_in_length"
+#define SESSION_CHAP_ALGS	"node.session.auth.chap_algs"
 #define SESSION_REPLACEMENT_TMO	"node.session.timeo.replacement_timeout"
 #define SESSION_ABORT_TMO	"node.session.err_timeo.abort_timeout"
 #define SESSION_LU_RESET_TMO	"node.session.err_timeo.lu_reset_timeout"

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -243,6 +243,7 @@ typedef struct iscsi_session {
 	char username_in[AUTH_STR_MAX_LEN];
 	uint8_t password_in[AUTH_STR_MAX_LEN];
 	int password_in_length;
+	unsigned int chap_algs[AUTH_CHAP_ALG_MAX_COUNT];
 	iscsi_conn_t conn[ISCSI_CONN_MAX];
 	uint64_t param_mask;
 

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -94,6 +94,8 @@ int iscsi_setup_authentication(struct iscsi_session *session,
 		memcpy(session->password_in, auth_cfg->password_in,
 		       session->password_in_length);
 
+	memcpy(session->chap_algs, auth_cfg->chap_algs, sizeof(auth_cfg->chap_algs));
+
 	if (session->password_length || session->password_in_length) {
 		/* setup the auth buffers */
 		session->auth_buffers[0].address = &session->auth_client_block;

--- a/usr/login.c
+++ b/usr/login.c
@@ -1262,6 +1262,17 @@ check_for_authentication(iscsi_session_t *session,
 		goto end;
 	}
 
+	int value_list[AUTH_CHAP_ALG_MAX_COUNT];
+
+	if (acl_set_chap_alg_list(auth_client,
+				acl_init_chap_digests(value_list,
+					session->chap_algs,
+					AUTH_CHAP_ALG_MAX_COUNT),
+				value_list) != AUTH_STATUS_NO_ERROR) {
+		log_error("Couldn't set CHAP algorithm list");
+		goto end;
+	}
+
 	if (acl_set_ip_sec(auth_client, 1) != AUTH_STATUS_NO_ERROR) {
 		log_error("Couldn't set IPSec");
 		goto end;


### PR DESCRIPTION
Introduces support for preference lists in configuration files, and uses
that for the 'node.session.auth.chap_algs' setting.

This is also re-used for discovery authentication, rather than have two
different configurations.

It turns out that adding to the configuration file is way harder than adding new digest algorithms to the CHAP code itself was.  Having two sets of idbm.c to worry about depending on which commands are being run really doesn't help either.

I've tried breaking this every way I can think of, and I can't make it fall over anymore.
It seems far enough along to share.  Let me know if you spot anything that needs changing.