### PR TITLE
Fix bug with libopeniscsiusr.pc

### DIFF
--- a/libopeniscsiusr/libopeniscsiusr.pc.in
+++ b/libopeniscsiusr/libopeniscsiusr.pc.in
@@ -5,5 +5,5 @@ Name: libopeniscsiusr
 Version: __VERSION__
 Description: iSCSI userspace library
 Requires:
-Libs: -L${libdir} -liscsiusr
+Libs: -L${libdir} -lopeniscsiusr
 Cflags: -I${includedir}


### PR DESCRIPTION
The library name is libopeniscsiusr, so the -l linker option should be `-lopeniscsiusr` instead of `-liscsiusr`.