### PR TITLE
Fix compiler issues

### DIFF
--- a/include/iscsi_err.h
+++ b/include/iscsi_err.h
@@ -4,7 +4,7 @@
 #ifndef _ISCSI_ERR_
 #define _ISCSI_ERR_
 
-enum {
+enum iscsi_error_list {
 	ISCSI_SUCCESS			= 0,
 	/* Generic error */
 	ISCSI_ERR			= 1,
@@ -73,7 +73,9 @@ enum {
 
 	/* Always last. Indicates end of error code space */
 	ISCSI_MAX_ERR_VAL,
-} iscsi_err;
+};
+
+extern enum iscsi_error_list iscsi_err;
 
 extern void iscsi_err_print_msg(int err);
 extern char *iscsi_err_to_str(int err);

--- a/iscsiuio/configure.ac
+++ b/iscsiuio/configure.ac
@@ -78,7 +78,7 @@ AC_CONFIG_COMMANDS([default],[[
     else
         echo 'char *build_date = "'`date`'";' > src/unix/build_date.c
     fi
-    echo 'char *build_date;'> src/unix/build_date.h
+    echo 'extern char *build_date;'> src/unix/build_date.h
 ]],[[]])
 
 AC_PREFIX_DEFAULT()

--- a/iscsiuio/src/uip/uip.h
+++ b/iscsiuio/src/uip/uip.h
@@ -70,8 +70,8 @@ struct uip_stack;
 typedef u16_t uip_ip4addr_t[2];
 typedef u16_t uip_ip6addr_t[8];
 
-const uip_ip6addr_t all_zeroes_addr6;
-const uip_ip4addr_t all_zeroes_addr4;
+extern const uip_ip6addr_t all_zeroes_addr6;
+extern const uip_ip4addr_t all_zeroes_addr4;
 
 #define ETH_BUF(buf) ((struct uip_eth_hdr *)buf)
 #define VLAN_ETH_BUF(buf) ((struct uip_vlan_eth_hdr *)buf)

--- a/iscsiuio/src/unix/nic_utils.c
+++ b/iscsiuio/src/unix/nic_utils.c
@@ -1252,7 +1252,7 @@ int get_iscsi_transport_handle(nic_t *nic, uint64_t *handle)
 	if (rc != 0)
 		goto error;
 
-	elements_read = sscanf(raw, "%lu", handle);
+	elements_read = sscanf(raw, "%" PRIu64, handle);
 	if (elements_read != 1) {
 		LOG_ERR(PFX "%s: Couldn't parse transport handle from %s",
 			nic->log_name, temp_path);

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -35,7 +35,7 @@ endif
 PKG_CONFIG = /usr/bin/pkg-config
 
 CFLAGS ?= -O2 -g
-WARNFLAGS ?= -Wall -Wextra -Werror -Wstrict-prototypes
+WARNFLAGS ?= -Wall -Wextra -Werror -Wstrict-prototypes -fno-common
 CFLAGS += $(WARNFLAGS) -I../include -I. -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -35,7 +35,7 @@ endif
 PKG_CONFIG = /usr/bin/pkg-config
 
 CFLAGS ?= -O2 -g
-WARNFLAGS ?= -Wall -Wstrict-prototypes
+WARNFLAGS ?= -Wall -Wextra -Werror -Wstrict-prototypes
 CFLAGS += $(WARNFLAGS) -I../include -I. -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)

--- a/usr/actor.c
+++ b/usr/actor.c
@@ -239,7 +239,8 @@ actor_poll(void)
 		uint64_t time_left = actor_time_left(thread, current_time);
 		if (time_left) {
 			log_debug(7, "thread %08lx due %" PRIu64 ", wait %" PRIu64 " more",
-				  (long)thread, thread->ttschedule, time_left);
+				  (long)thread,
+				  (uint64_t)thread->ttschedule, time_left);
 
 			alarm(time_left);
 			break;
@@ -251,7 +252,7 @@ actor_poll(void)
 		log_debug(2, "thread %08lx was scheduled for "
 			  "%" PRIu64 ", curtime %" PRIu64 " q_forw %p "
 			  "&pend_list %p",
-			  (long)thread, thread->ttschedule,
+			  (long)thread, (uint64_t)thread->ttschedule,
 			  current_time, pend_list.next, &pend_list);
 
 		list_add_tail(&thread->list, &ready_list);

--- a/usr/actor.c
+++ b/usr/actor.c
@@ -31,7 +31,7 @@ static LIST_HEAD(ready_list);
 static volatile int poll_in_progress;
 
 static uint64_t
-actor_time_left(actor_t *thread, uint64_t current_time)
+actor_time_left(actor_t *thread, time_t current_time)
 {
 	if (current_time > thread->ttschedule)
 		return 0;

--- a/usr/discoveryd.c
+++ b/usr/discoveryd.c
@@ -488,7 +488,7 @@ static void isns_reg_refresh_by_eid_qry(void *data)
 	int status, timeout;
 
 	log_debug(1, "Refresh registration using eid qry");
-	if (refresh_data->start_time + refresh_data->interval <= time(NULL)) {
+	if ((time_t)(refresh_data->start_time + refresh_data->interval) <= time(NULL)) {
 		log_error("Could not refresh registration with server "
 			  "before registration period. Starting new "
 			  "registration.");

--- a/usr/discoveryd.c
+++ b/usr/discoveryd.c
@@ -387,7 +387,7 @@ free_ifaces:
 	return rc;
 }
 
-static void isns_reg_refresh_with_disc(void *data)
+static void isns_reg_refresh_with_disc(__attribute__((unused))void *data)
 {
 	int retries = 0, rc;
 
@@ -551,7 +551,7 @@ static int isns_setup_registration_refresh(isns_simple_t *rsp, int poll_inval)
 {
 	isns_object_list_t objs = ISNS_OBJECT_LIST_INIT;
 	struct isns_refresh_data *refresh_data;
-	int status, i, rc = 0;
+	int status, rc = 0;
 	uint32_t interval = 0;
 
 	status = isns_query_response_get_objects(rsp, &objs);
@@ -562,7 +562,7 @@ static int isns_setup_registration_refresh(isns_simple_t *rsp, int poll_inval)
 		return ISCSI_ERR;
 	}
 
-	for (i = 0; i < objs.iol_count; ++i) {
+	for (unsigned int i = 0; i < objs.iol_count; ++i) {
 		isns_object_t *obj = objs.iol_data[i]; 
 
 		if (!isns_object_is_entity(obj))
@@ -605,7 +605,7 @@ static int isns_setup_registration_refresh(isns_simple_t *rsp, int poll_inval)
 
 	if (poll_inval > 0) {
 		/* user wants to override server and do disc */
-		if (isns_refresh_interval > poll_inval)
+		if ((int)isns_refresh_interval > poll_inval)
 			isns_refresh_interval = poll_inval;
 		isns_add_timer(isns_refresh_interval,
 			       isns_reg_refresh_with_disc,
@@ -831,9 +831,11 @@ done:
 	return rc;
 }
 
-static void isns_scn_callback(isns_db_t *db, uint32_t bitmap,
-			      isns_object_template_t *node_type,
-			      const char *node_name, const char *dst_name)
+static void isns_scn_callback(__attribute__((unused))isns_db_t *db,
+			      uint32_t bitmap,
+			      __attribute__((unused))isns_object_template_t *node_type,
+			      const char *node_name,
+			      const char *dst_name)
 {
 	log_error("SCN for initiator: %s (Target: %s, Event: %s.)",
 		    dst_name, node_name, isns_event_string(bitmap));
@@ -1052,7 +1054,7 @@ free_ifaces:
 	}
 }
 
-static void do_st_disc_and_login(const char *def_iname,
+static void do_st_disc_and_login(__attribute__((unused))const char *def_iname,
 				 struct discovery_rec *drec, int poll_inval)
 {
 	if (poll_inval < 0)
@@ -1067,7 +1069,8 @@ static void do_st_disc_and_login(const char *def_iname,
 	discoveryd_stop();
 }
 
-static int st_start(void *data, struct discovery_rec *drec)
+static int st_start(__attribute__((unused))void *data,
+		    struct discovery_rec *drec)
 {
 	log_debug(1, "st_start %s:%d %d", drec->address, drec->port,
 		  drec->u.sendtargets.use_discoveryd);

--- a/usr/flashnode.c
+++ b/usr/flashnode.c
@@ -48,8 +48,10 @@ char *to_key(const char *fmt)
 	return key;
 }
 
-int flashnode_info_print_flat(void *data, struct flashnode_rec *fnode,
-			      uint32_t host_no, uint32_t flashnode_idx)
+int flashnode_info_print_flat(__attribute__((unused))void *data,
+			      struct flashnode_rec *fnode,
+			      __attribute__((unused))uint32_t host_no,
+			      uint32_t flashnode_idx)
 {
 	printf("%s: [%d] ", fnode->transport_name, flashnode_idx);
 	if (!strlen((char *)fnode->conn[0].ipaddress))
@@ -207,7 +209,8 @@ static int flashnode_fill_ipaddr(struct flashnode_rec *fnode, struct iovec *iov,
 	return rc;
 }
 
-static int flashnode_fill_uint8(struct flashnode_rec *fnode, struct iovec *iov,
+static int flashnode_fill_uint8(__attribute__((unused))struct flashnode_rec *fnode,
+				struct iovec *iov,
 				int param_type, uint8_t val)
 {
 	struct iscsi_flashnode_param_info *fnode_param;
@@ -229,7 +232,8 @@ static int flashnode_fill_uint8(struct flashnode_rec *fnode, struct iovec *iov,
 	return 0;
 }
 
-static int flashnode_fill_uint16(struct flashnode_rec *fnode, struct iovec *iov,
+static int flashnode_fill_uint16(__attribute__((unused))struct flashnode_rec *fnode,
+				 struct iovec *iov,
 				 int param_type, uint16_t val)
 {
 	struct iscsi_flashnode_param_info *fnode_param;
@@ -251,7 +255,8 @@ static int flashnode_fill_uint16(struct flashnode_rec *fnode, struct iovec *iov,
 	return 0;
 }
 
-static int flashnode_fill_uint32(struct flashnode_rec *fnode, struct iovec *iov,
+static int flashnode_fill_uint32(__attribute__((unused))struct flashnode_rec *fnode,
+				 struct iovec *iov,
 				 int param_type, uint32_t val)
 {
 	struct iscsi_flashnode_param_info *fnode_param;
@@ -273,7 +278,8 @@ static int flashnode_fill_uint32(struct flashnode_rec *fnode, struct iovec *iov,
 	return 0;
 }
 
-static int flashnode_fill_str(struct flashnode_rec *fnode, struct iovec *iov,
+static int flashnode_fill_str(__attribute__((unused))struct flashnode_rec *fnode,
+			      struct iovec *iov,
 			      int param_type, char *buf, int buflen)
 {
 	struct iscsi_flashnode_param_info *fnode_param;

--- a/usr/host.c
+++ b/usr/host.c
@@ -92,7 +92,8 @@ static void print_host_info(struct iface_rec *iface, char *prefix)
 		printf("%sNetdev: %s\n", prefix, UNKNOWN_VALUE);
 }
 
-static int host_info_print_flat(void *data, struct host_info *hinfo)
+static int host_info_print_flat(__attribute__((unused))void *data,
+				struct host_info *hinfo)
 {
 	struct iface_rec *iface = &hinfo->iface;
 
@@ -310,7 +311,8 @@ int host_info_print(int info_level, uint32_t host_no,
 		arg.flags = flags;
 		arg.ses = ses;
 		arg.se_count = se_count;
-		if (host_no != -1) {
+		/* set host_no if not yet done */
+		if (host_no > MAX_HOST_NO) {
 			struct host_info hinfo;
 
 			memset(&hinfo, 0, sizeof(struct host_info));

--- a/usr/host.h
+++ b/usr/host.h
@@ -7,7 +7,7 @@
 #include "types.h"
 #include "config.h"
 
-#define MAX_HOST_NO UINT_MAX
+#define MAX_HOST_NO UINT32_MAX
 
 #define MAX_CHAP_ENTRIES 2048
 #define MAX_CHAP_BUF_SZ 4096

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -169,10 +169,10 @@ static struct idbm *db;
 #define __recinfo_int_list(_key,_info,_rec,_name,_show,_tbl,_n,_mod) do { \
 	_info[_n].type = TYPE_INT_LIST; \
 	strlcpy(_info[_n].name, _key, NAME_MAXVAL); \
-	for(int _i = 0; _i < ARRAY_LEN(_rec->_name); _i++) { \
-		if (_rec->_name[_i] != ~0) { \
-			for (int _j = 0; _j < ARRAY_LEN(_tbl); _j++) { \
-				if (_tbl[_j].value == _rec->_name[_i]) { \
+	for (unsigned long _i = 0; _i < ARRAY_LEN(_rec->_name); _i++) {	\
+		if (_rec->_name[_i] != (unsigned)~0) {			\
+			for (unsigned long _j = 0; _j < ARRAY_LEN(_tbl); _j++) {	\
+				if (_tbl[_j].value == (int)_rec->_name[_i]) { \
 					strcat(_info[_n].value, _tbl[_j].name); \
 					strcat(_info[_n].value, ","); \
 					break; \
@@ -1072,6 +1072,8 @@ setup_passwd_len:
 						goto updated;
 					}
 				}
+				/* internal error if reached ?? */
+				break;
 			case TYPE_INT_LIST:
 				if (!info[i].data)
 					continue;
@@ -1351,7 +1353,7 @@ int idbm_print_flashnode_info(struct flashnode_rec *fnode)
 	return 0;
 }
 
-int idbm_print_node_flat(void *data, node_rec_t *rec)
+int idbm_print_node_flat(__attribute__((unused))void *data, node_rec_t *rec)
 {
 	if (strchr(rec->conn[0].address, '.'))
 		printf("%s:%d,%d %s\n", rec->conn[0].address, rec->conn[0].port,

--- a/usr/iface.c
+++ b/usr/iface.c
@@ -513,7 +513,8 @@ static int iface_setup_binding_from_kern_iface(void *data,
 	return 0;
 }
 
-static int __iface_setup_host_bindings(void *data, struct host_info *hinfo)
+static int __iface_setup_host_bindings(__attribute__((unused))void *data,
+				       struct host_info *hinfo)
 {
 	struct iface_rec *def_iface;
 	struct iscsi_transport *t;
@@ -841,7 +842,8 @@ static int iface_print_nodes(void *data, node_rec_t *rec)
  * have the binding info. When we store the iface specific node settings
  * in the iface record then it will look different.
  */
-int iface_print_tree(void *data, struct iface_rec *iface)
+int iface_print_tree(__attribute__((unused))void *data,
+		     struct iface_rec *iface)
 {
 	struct node_rec last_rec;
 	struct iface_print_node_data print_data;

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -266,6 +266,8 @@ typedef struct iscsi_session {
 	queue_task_t *notify_qtask;
 } iscsi_session_t;
 
+#define	INVALID_SESSION_ID	(uint32_t)-1
+
 /* login.c */
 
 #define ISCSI_SESSION_TYPE_NORMAL 0

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -53,7 +53,7 @@ struct iscsi_session *session_find_by_sid(uint32_t sid)
 	return NULL;
 }
 
-const static unsigned int align_32_down(unsigned int param)
+static unsigned int align_32_down(unsigned int param)
 {
 	return param & ~0x3;
 }

--- a/usr/io.c
+++ b/usr/io.c
@@ -58,7 +58,7 @@ do { \
 static int timedout;
 
 static void
-sigalarm_handler(int unused)
+sigalarm_handler(__attribute__((unused))int unused)
 {
 	timedout = 1;
 }
@@ -503,8 +503,12 @@ iscsi_log_text(struct iscsi_hdr *pdu, char *data)
 }
 
 int
-iscsi_io_send_pdu(iscsi_conn_t *conn, struct iscsi_hdr *hdr,
-	       int hdr_digest, char *data, int data_digest, int timeout)
+iscsi_io_send_pdu(iscsi_conn_t *conn,
+		  struct iscsi_hdr *hdr,
+		  __attribute__((unused))int hdr_digest,
+		  char *data,
+		  __attribute__((unused))int data_digest,
+		  int timeout)
 {
 	int rc, ret = 0;
 	char *header = (char *) hdr;
@@ -665,9 +669,13 @@ iscsi_io_send_pdu(iscsi_conn_t *conn, struct iscsi_hdr *hdr,
 }
 
 int
-iscsi_io_recv_pdu(iscsi_conn_t *conn, struct iscsi_hdr *hdr,
-	       int hdr_digest, char *data, int max_data_length, int data_digest,
-	       int timeout)
+iscsi_io_recv_pdu(iscsi_conn_t *conn,
+		  struct iscsi_hdr *hdr,
+		  __attribute__((unused))int hdr_digest,
+		  char *data,
+		  int max_data_length,
+		  __attribute__((unused))int data_digest,
+		  int timeout)
 {
 	uint32_t h_bytes = 0;
 	uint32_t ahs_bytes = 0;

--- a/usr/iscsi_err.c
+++ b/usr/iscsi_err.c
@@ -21,6 +21,8 @@
 #include "iscsi_err.h"
 #include "log.h"
 
+enum iscsi_error_list iscsi_err;
+
 static char *iscsi_err_msgs[] = {
 	/* 0 */ "",
 	/* 1 */ "unknown error",

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1781,8 +1781,8 @@ struct iscsi_transport *iscsi_sysfs_get_transport_by_hba(uint32_t host_no)
 	char id[NAME_SIZE];
 	int rc;
 
-	if (host_no == -1)
-		return NULL;
+	if (host_no > MAX_HOST_NO)
+		return NULL;	/* not set? */
 
 	snprintf(id, sizeof(id), ISCSI_HOST_ID, host_no);
 	rc = sysfs_get_str(id, SCSI_HOST_SUBSYS, "proc_name", name,
@@ -1914,7 +1914,8 @@ void iscsi_sysfs_set_queue_depth(void *data, int hostno, int target, int lun)
 		log_error("Could not queue depth for LUN %d err %d.", lun, err);
 }
 
-void iscsi_sysfs_set_device_online(void *data, int hostno, int target, int lun)
+void iscsi_sysfs_set_device_online(__attribute__((unused))void *data,
+				   int hostno, int target, int lun)
 {
 	char *write_buf = "running\n";
 	char id[NAME_SIZE];
@@ -1930,7 +1931,8 @@ void iscsi_sysfs_set_device_online(void *data, int hostno, int target, int lun)
 		log_error("Could not online LUN %d err %d.", lun, err);
 }
 
-void iscsi_sysfs_rescan_device(void *data, int hostno, int target, int lun)
+void iscsi_sysfs_rescan_device(__attribute__((unused))void *data,
+			       int hostno, int target, int lun)
 {
 	char *write_buf = "1";
 	char id[NAME_SIZE];

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -2677,7 +2677,8 @@ delete_fail:
 		memset(&hinfo, 0, sizeof(struct host_info));
 		hinfo.host_no = host_no;
 		if (iscsi_sysfs_get_hostinfo_by_host_no(&hinfo)) {
-			log_error("Could not match host%lu to ifaces.", host_no);
+			log_error("Could not match host%" PRIu64 " to ifaces.",
+				  host_no);
 			rc = ISCSI_ERR_INVAL;
 			break;
 		}
@@ -2688,7 +2689,7 @@ delete_fail:
 			break;
 		}
 
-		printf("Applied settings to ifaces attached to host%lu.\n",
+		printf("Applied settings to ifaces attached to host%" PRIu64 ".\n",
 		       host_no);
 		break;
 	default:

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -189,7 +189,8 @@ setup_rec_from_negotiated_values(node_rec_t *rec, struct session_info *info)
 	}
 }
 
-static int sync_session(void *data, struct session_info *info)
+static int sync_session(__attribute__((unused))void *data,
+			struct session_info *info)
 {
 	node_rec_t rec, sysfsrec;
 	iscsiadm_req_t req;

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -299,9 +299,8 @@ int uip_broadcast(void *buf, size_t buf_len, int fd_flags, uint32_t *status)
 		/*  Wait for the response */
 		err = read(fd, &rsp, sizeof(rsp));
 		if (err == sizeof(rsp)) {
-			log_debug(3, "Broadcasted to uIP with length: %ld "
-				     "cmd: 0x%x rsp: 0x%x", buf_len,
-				     rsp.command, rsp.err);
+			log_debug(3, "Broadcasted to uIP with length: %zu cmd: 0x%x rsp: 0x%x",
+				  buf_len, rsp.command, rsp.err);
 			err = 0;
 			break;
 		} else if ((err == -1) && (errno == EAGAIN)) {

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -256,7 +256,8 @@ int uip_broadcast(void *buf, size_t buf_len, int fd_flags, uint32_t *status)
 	iscsid_uip_rsp_t rsp;
 	int flags;
 	int count;
-
+	size_t write_res;
+	
 	err = uip_connect(&fd);
 	if (err) {
 		log_warning("uIP daemon is not up");
@@ -266,10 +267,10 @@ int uip_broadcast(void *buf, size_t buf_len, int fd_flags, uint32_t *status)
 	log_debug(3, "connected to uIP daemon");
 
 	/*  Send the data to uIP */
-	err = write(fd, buf, buf_len);
-	if (err != buf_len) {
+	write_res = write(fd, buf, buf_len);
+	if (write_res != buf_len) {
 		log_error("got write error (%d/%d), daemon died?",
-			  err, errno);
+			  (int)write_res, errno);
 		close(fd);
 		return ISCSI_ERR_ISCSID_COMM_ERR;
 	}

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -295,7 +295,10 @@ static int setup_session(void)
 	return rc;
 }
 
-int session_in_use(int sid) { return 0; }
+int session_in_use(__attribute__((unused))int sid)
+{
+	return 0;
+}
 
 static void catch_signal(int signo)
 {

--- a/usr/local_strings.c
+++ b/usr/local_strings.c
@@ -74,7 +74,7 @@ int str_enlarge_data(struct str_buffer *s, int length)
 	if (s) {
 		s->data_length += length;
 		if (s->data_length > s->allocated_length) {
-			log_debug(7, "enlarge buffer from %lu to %lu",
+			log_debug(7, "enlarge buffer from %zu to %zu",
 				  s->allocated_length, s->data_length);
 			new_buf = realloc(s->buffer, s->data_length);
 			if (!new_buf) {

--- a/usr/log.c
+++ b/usr/log.c
@@ -33,6 +33,7 @@
 
 char *log_name;
 int log_level = 0;
+struct logarea *la = NULL;
 
 static int log_stop_daemon = 0;
 static void (*log_func)(int prio, void *priv, const char *fmt, va_list ap);

--- a/usr/log.c
+++ b/usr/log.c
@@ -186,7 +186,7 @@ int log_enqueue (int prio, const char * fmt, va_list ap)
 
 	/* not enough space on tail : rewind */
 	if (la->head <= la->tail &&
-	    (len + sizeof(struct logmsg)) > (la->end - la->tail)) {
+	    (long)(len + sizeof(struct logmsg)) > (la->end - la->tail)) {
 		logdbg(stderr, "enqueue: rewind tail to %p\n", la->tail);
 			la->tail = la->start;
 
@@ -196,7 +196,7 @@ int log_enqueue (int prio, const char * fmt, va_list ap)
 
 	/* not enough space on head : drop msg */
 	if (la->head > la->tail &&
-	    (len + sizeof(struct logmsg)) > (la->head - la->tail)) {
+	    (long)(len + sizeof(struct logmsg)) > (la->head - la->tail)) {
 		logdbg(stderr, "enqueue: log area overrun, drop msg\n");
 
 		if (!la->empty)
@@ -262,7 +262,10 @@ static void log_syslog (void * buff)
 	syslog(msg->prio, "%s", (char *)&msg->str);
 }
 
-void log_do_log_daemon(int prio, void *priv, const char *fmt, va_list ap)
+void log_do_log_daemon(int prio,
+		       __attribute__((unused))void *priv,
+		       const char *fmt,
+		       va_list ap)
 {
 	struct sembuf ops[1];
 
@@ -282,7 +285,10 @@ void log_do_log_daemon(int prio, void *priv, const char *fmt, va_list ap)
 		syslog(LOG_ERR, "semop up failed");
 }
 
-void log_do_log_std(int prio, void *priv, const char *fmt, va_list ap)
+void log_do_log_std(int prio,
+		    __attribute__((unused))void *priv,
+		    const char *fmt,
+		    va_list ap)
 {
 	if (prio == LOG_INFO) {
 		vfprintf(stdout, fmt, ap);

--- a/usr/log.h
+++ b/usr/log.h
@@ -64,7 +64,7 @@ struct logarea {
 	union semun semarg;
 };
 
-struct logarea *la;
+extern struct logarea *la;
 
 extern int log_init(char *program_name, int size,
 	void (*func)(int prio, void *priv, const char *fmt, va_list ap),

--- a/usr/login.c
+++ b/usr/login.c
@@ -62,14 +62,14 @@ iscsi_add_text(struct iscsi_hdr *pdu, char *data, int max_data_length,
 	}
 
 	/* param */
-	strncpy(text, param, param_len);
+	memcpy(text, param, param_len);
 	text += param_len;
 
 	/* separator */
 	*text++ = ISCSI_TEXT_SEPARATOR;
 
 	/* value */
-	strncpy(text, value, value_len);
+	memcpy(text, value, value_len);
 	text += value_len;
 
 	/* NUL */
@@ -399,7 +399,7 @@ get_op_params_text_keys(iscsi_session_t *session, int cid,
 			 * what the target gave us.
 			 */
 			if (!conn_rec->iscsi.MaxXmitDataSegmentLength ||
-			    tgt_max_xmit < conn->max_xmit_dlength)
+			    tgt_max_xmit < (int)conn->max_xmit_dlength)
 				conn->max_xmit_dlength = tgt_max_xmit;
 		}
 		text = value_end;

--- a/usr/mgmt_ipc.c
+++ b/usr/mgmt_ipc.c
@@ -84,7 +84,7 @@ int mgmt_ipc_systemd(void)
 
 	env = getenv("LISTEN_PID");
 
-	if (!env || (strtoul(env, NULL, 10) != getpid()))
+	if (!env || ((pid_t)strtoul(env, NULL, 10) != getpid()))
 		return -EINVAL;
 
 	env = getenv("LISTEN_FDS");
@@ -211,7 +211,7 @@ mgmt_ipc_cfg_filename(queue_task_t *qtask)
 }
 
 static int
-mgmt_ipc_conn_add(queue_task_t *qtask)
+mgmt_ipc_conn_add(__attribute__((unused))queue_task_t *qtask)
 {
 	return ISCSI_ERR;
 }
@@ -224,7 +224,7 @@ mgmt_ipc_immediate_stop(queue_task_t *qtask)
 }
 
 static int
-mgmt_ipc_conn_remove(queue_task_t *qtask)
+mgmt_ipc_conn_remove(__attribute__((unused))queue_task_t *qtask)
 {
 	return ISCSI_ERR;
 }
@@ -300,25 +300,29 @@ mgmt_ipc_notify_common(queue_task_t *qtask, int (*handler)(int, char **))
 /* Replace these dummies as you implement them
    elsewhere */
 static int
-iscsi_discovery_add_node(int argc, char **argv)
+iscsi_discovery_add_node(__attribute__((unused))int argc,
+			 __attribute__((unused))char **argv)
 {
 	return ISCSI_SUCCESS;
 }
 
 static int
-iscsi_discovery_del_node(int argc, char **argv)
+iscsi_discovery_del_node(__attribute__((unused))int argc,
+			 __attribute__((unused))char **argv)
 {
 	return ISCSI_SUCCESS;
 }
 
 static int
-iscsi_discovery_add_portal(int argc, char **argv)
+iscsi_discovery_add_portal(__attribute__((unused))int argc,
+			   __attribute__((unused))char **argv)
 {
 	return ISCSI_SUCCESS;
 }
 
 static int
-iscsi_discovery_del_portal(int argc, char **argv)
+iscsi_discovery_del_portal(__attribute__((unused))int argc,
+			   __attribute__((unused))char **argv)
 {
 	return ISCSI_SUCCESS;
 }
@@ -509,8 +513,10 @@ void mgmt_ipc_handle(int accept_fd)
 	command = qtask->req.command;
 	qtask->rsp.command = command;
 
-	if (0 <= command && command < __MGMT_IPC_MAX_COMMAND)
+	if (command > 0 &&
+	    command < __MGMT_IPC_MAX_COMMAND)
 		handler = mgmt_ipc_functions[command];
+
 	if (handler != NULL) {
 		/* If the handler returns OK, this means it
 		 * already sent the reply. */

--- a/usr/netlink.c
+++ b/usr/netlink.c
@@ -137,7 +137,7 @@ nlpayload_read(int ctrl_fd, char *data, int count, int flags)
 	iov.iov_len = NLMSG_SPACE(count);
 
 	if (iov.iov_len > NLM_BUF_DEFAULT_MAX) {
-		log_error("Cannot read %lu bytes. nlm_recvbuf too small.",
+		log_error("Cannot read %zu bytes. nlm_recvbuf too small.",
 			  iov.iov_len);
 		return -1;
 	}

--- a/usr/netlink.c
+++ b/usr/netlink.c
@@ -581,7 +581,7 @@ ksend_pdu_begin(uint64_t transport_handle, uint32_t sid, uint32_t cid,
 		exit(-EIO);
 	}
 
-	if (total_xmitlen > PDU_SENDBUF_DEFAULT_MAX) {
+	if (total_xmitlen > (int)PDU_SENDBUF_DEFAULT_MAX) {
 		log_error("BUG: Cannot send %d bytes.", total_xmitlen);
 		exit(-EINVAL);
 	}
@@ -603,8 +603,8 @@ ksend_pdu_begin(uint64_t transport_handle, uint32_t sid, uint32_t cid,
 }
 
 static int
-ksend_pdu_end(uint64_t transport_handle, uint32_t sid, uint32_t cid,
-	      int *retcode)
+ksend_pdu_end(__attribute__((unused))uint64_t transport_handle,
+	      uint32_t sid, uint32_t cid, int *retcode)
 {
 	int rc;
 	struct iscsi_uevent *ev;
@@ -929,7 +929,7 @@ ktransport_ep_disconnect(iscsi_conn_t *conn)
 
 	log_debug(7, "in %s", __FUNCTION__);
 
-	if (conn->transport_ep_handle == -1)
+	if (conn->transport_ep_handle == (uint64_t)-1)
 		return;
 
 	memset(&ev, 0, sizeof(struct iscsi_uevent));

--- a/usr/uip_mgmt_ipc.c
+++ b/usr/uip_mgmt_ipc.c
@@ -22,9 +22,9 @@
 #include "iscsid_req.h"
 #include "iscsi_err.h"
 
-int uip_broadcast_params(struct iscsi_transport *t,
+int uip_broadcast_params(__attribute__((unused))struct iscsi_transport *t,
 			 struct iface_rec *iface,
-			 struct iscsi_session *session)
+			 __attribute__((unused))struct iscsi_session *session)
 {
 	struct iscsid_uip_broadcast broadcast;
 
@@ -42,7 +42,7 @@ int uip_broadcast_params(struct iscsi_transport *t,
 			     sizeof(*iface), O_NONBLOCK, NULL);
 }
 
-int uip_broadcast_ping_req(struct iscsi_transport *t,
+int uip_broadcast_ping_req(__attribute__((unused))struct iscsi_transport *t,
 			   struct iface_rec *iface, int datalen,
 			   struct sockaddr_storage *dst_addr, uint32_t *status)
 {


### PR DESCRIPTION
These changes are all aimed at fixing things that an updated gcc doesn't like, including compiling with "-fno-common". Also, 586 compilation errors are fixed, since we still support 32-bit Intel. Lastly, -Werror is added to "usr/Makefile" so that future errors are caught. Tested with gcc-9 on 64- and 32-bit Intel architectures.

There _should_ be no functional change, so only minor testing was done.