### PR TITLE
Avoid logout of iscsi boot session

### DIFF
--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -391,6 +391,9 @@ __logout_by_startup(void *data, struct list_head *list,
 	if (rec.startup == ISCSI_STARTUP_ONBOOT)
 		return -1;
 
+	if (rec.disc_type == DISCOVERY_TYPE_FW)
+		return -1;
+
 	if (match_startup_mode(&rec, mode))
 		return -1;
 


### PR DESCRIPTION
OS is stuck after reboot command on iscsi boot environment. 
The root cause is that the systemd can't access the iscsi boot disk after iscsi service was stopped by
reboot command. So the systemd can't execute remaining jobs. As a result, OS is stuck.
This patch avoids logout of iscsi boot session.