### PR TITLE
Check whether socket is opened successfully in find_vlan_dev func

### DIFF
--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -192,6 +192,10 @@ static char *find_vlan_dev(char *netdev, int vlan_id) {
 	int sockfd, i, rc;
 
 	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		log_error("Could not open socket for ioctl.");
+		return NULL;
+	}
 
 	strlcpy(if_hwaddr.ifr_name, netdev, IFNAMSIZ);
 	ioctl(sockfd, SIOCGIFHWADDR, &if_hwaddr);


### PR DESCRIPTION
In find_vlan_dev func, socket should be checked before used.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>