### PR TITLE
Preparing for version 2.1.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,36 @@
+open-iscsi-2.1.0 - open-iscsi-2.1.1
+
+# output from "git shortlog --no-merges 2.1.0..HEAD"
+
+Chris Leech (2):
+      configuration support for CHAP algorithms
+      Revert "Out-of-bounds read: Overrunning array of 8 2-byte elements"
+
+Kiyotaka Nakamura (1):
+      Avoid logout of iscsi boot session
+
+Lee Duncan (13):
+      Fixed Changelog message, first line
+      Enabled compiler checking options, fixed issues.
+      Updates to support gcc -fno-common option.
+      Fix 586 compiler issues.
+      Beginning to get python tests set up.
+      First 32 tests working?
+      64 tests now working and passing
+      Update TODO list
+      Add in "-V" for version info
+      Test code rearranged to make discovery work.
+      more things to do
+      Allow sub-tests to be specified.
+      Fix memory leaks in libopeniscsiusr/idbm.c
+
+Patrick McCarty (1):
+      Fix bug with libopeniscsiusr.pc
+
+l00464806 (1):
+      Check whether socket is opened successfully in find_vlan_dev func
+
+
 open-iscsi-2.0.878 - open-iscsi-2.1.0
 
 # output from "git shortlog --no-merges 2.0.878..HEAD"

--- a/libopeniscsiusr/version.h
+++ b/libopeniscsiusr/version.h
@@ -25,6 +25,6 @@
  * This may not be the same value as the kernel versions because
  * some other maintainer could merge a patch without going through us
  */
-#define ISCSI_VERSION_STR	"2.1.0"
+#define ISCSI_VERSION_STR	"2.1.1"
 
 #endif  /* End of __ISCSI_OPEN_USR_VERSION_H__ */

--- a/usr/version.h
+++ b/usr/version.h
@@ -6,7 +6,7 @@
  * This may not be the same value as the kernel versions because
  * some other maintainer could merge a patch without going through us
  */
-#define ISCSI_VERSION_STR	"2.1.0"
+#define ISCSI_VERSION_STR	"2.1.1"
 #define ISCSI_VERSION_FILE	"/sys/module/scsi_transport_iscsi/version"
 
 #endif


### PR DESCRIPTION
I will tag a new version if there are no objections. This has several useful bug fixes since 2.1.0.