### PR TITLE
iscsi-iname: fix iscsi-iname -p access NULL pointer without given IQN…

### DIFF
--- a/utils/iscsi-iname.c
+++ b/utils/iscsi-iname.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[])
 			exit(0);
 		} else if ( strcmp(prefix, "-p") == 0 ) {
 			prefix = argv[2];
-			if (strnlen(prefix, PREFIX_MAX_LEN + 1) > PREFIX_MAX_LEN) {
+			if (prefix && (strnlen(prefix, PREFIX_MAX_LEN + 1) > PREFIX_MAX_LEN)) {
 				printf("Error: Prefix cannot exceed %d "
 				       "characters.\n", PREFIX_MAX_LEN);
 				exit(1);


### PR DESCRIPTION
iscsi-iname -p access NULL pointer without give IQN prefix.

# iscsi-iname -p
Segmentation fault

Signed-off-by: Wu Bo <wubo40@huawei.com>
