### PR TITLE
Add Wants=remote-fs-pre.target for sequencing.

### DIFF
--- a/etc/systemd/iscsid.service
+++ b/etc/systemd/iscsid.service
@@ -4,6 +4,7 @@ Documentation=man:iscsid(8) man:iscsiuio(8) man:iscsiadm(8)
 DefaultDependencies=no
 After=network.target iscsiuio.service
 Before=remote-fs-pre.target
+Wants=remote-fs-pre.target
 
 [Service]
 Type=notify

--- a/etc/systemd/iscsiuio.service
+++ b/etc/systemd/iscsiuio.service
@@ -7,6 +7,7 @@ Requires=iscsid.service
 BindTo=iscsid.service
 After=network.target
 Before=remote-fs-pre.target iscsid.service
+Wants=remote-fs-pre.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
This ensures that either iscsiuio or iscsid service
makes sure the remote-fs-pre is run after.