### PR TITLE
Fix musl compiles v2

### DIFF
--- a/iscsiuio/src/unix/nic_nl.c
+++ b/iscsiuio/src/unix/nic_nl.c
@@ -50,7 +50,7 @@
 #include <linux/netlink.h>
 #include <iscsi_if.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/user.h>
 #include <sys/socket.h>

--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 #include <sys/param.h>
 #include <sys/socket.h>

--- a/usr/event_poll.c
+++ b/usr/event_poll.c
@@ -23,7 +23,7 @@
  */
 #include <stdlib.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/signalfd.h>

--- a/usr/io.c
+++ b/usr/io.c
@@ -24,7 +24,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>

--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -152,7 +152,9 @@ int increase_max_files(void)
 		log_debug(1, "Could not get file limit (err %d)", errno);
 		return errno;
 	}
-	log_debug(1, "Max file limits %lu %lu", rl.rlim_cur, rl.rlim_max);
+	log_debug(1, "Max file limits %lu %lu",
+		        (long unsigned)rl.rlim_cur,
+			(long unsigned)rl.rlim_max);
 
 	if (rl.rlim_cur < ISCSI_MAX_FILES)
 		rl.rlim_cur = ISCSI_MAX_FILES;
@@ -162,7 +164,8 @@ int increase_max_files(void)
 	err = setrlimit(RLIMIT_NOFILE, &rl);
 	if (err) {
 		log_debug(1, "Could not set file limit to %lu/%lu (err %d)",
-			  rl.rlim_cur, rl.rlim_max, errno);
+			  (long unsigned)rl.rlim_cur,
+			  (long unsigned)rl.rlim_max, errno);
 		return errno;
 	}
 

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -30,7 +30,6 @@
 #include <time.h>
 #include <sys/mman.h>
 #include <sys/utsname.h>
-#include <sys/signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 

--- a/usr/mgmt_ipc.c
+++ b/usr/mgmt_ipc.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <sys/un.h>
+#include <string.h>
 
 #include "iscsid.h"
 #include "idbm.h"

--- a/usr/netlink.c
+++ b/usr/netlink.c
@@ -30,7 +30,7 @@
 #include <asm/types.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <linux/netlink.h>
 
 #include "types.h"

--- a/usr/statics.c
+++ b/usr/statics.c
@@ -1,6 +1,6 @@
 #include <unistd.h>
 #include <pwd.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/types.h>
 
 static struct passwd root_pw = {
@@ -17,4 +17,3 @@ getpwuid(uid_t uid)
 		return 0;
 	}
 }
-


### PR DESCRIPTION
Some changes to support the "musl" minimalist C library. There should be no functional changes.