### PR TITLE
Ignore iface.example in iface match checks

### DIFF
--- a/usr/iface.c
+++ b/usr/iface.c
@@ -905,6 +905,9 @@ int iface_for_each_iface(void *data, int skip_def, int *nr_found,
 		    !strcmp(iface_dent->d_name, ".."))
 			continue;
 
+		if (!strcmp(iface_dent->d_name, "iface.example"))
+			continue;
+
 		log_debug(5, "iface_for_each_iface found %s",
 			 iface_dent->d_name);
 		iface = iface_alloc(iface_dent->d_name, &err);


### PR DESCRIPTION
Just a cleanup, as looking at the example file
didn't hurt anything, but did waste our time.