### PR TITLE
log:modify iSCSI shared memory permissions for logs 

### DIFF
--- a/utils/iscsi-iname.c
+++ b/utils/iscsi-iname.c
@@ -82,7 +82,6 @@ main(int argc, char *argv[])
 			prefix = argv[2];
 			if (strnlen(prefix, PREFIX_MAX_LEN + 1) > PREFIX_MAX_LEN) {
 				usage();
-
 				exit(1);
 			}
 		} else {

--- a/utils/iscsi-iname.c
+++ b/utils/iscsi-iname.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[])
 			exit(0);
 		} else if ( strcmp(prefix, "-p") == 0 ) {
 			prefix = argv[2];
-			if (strnlen(prefix, PREFIX_MAX_LEN + 1) > PREFIX_MAX_LEN) {
+			if (prefix && (strnlen(prefix, PREFIX_MAX_LEN + 1) > PREFIX_MAX_LEN)) {
 				printf("Error: Prefix cannot exceed %d "
 				       "characters.\n", PREFIX_MAX_LEN);
 				exit(1);


### PR DESCRIPTION
Iscsid log damon is responsible for reading data from shared memory
and writing syslog. Iscsid is the root user group.
Currently, it is not seen that non-root users need to read logs.
The principle of minimizing the use of permissions, all the permissions are changed from 644 to 600.

Signed-off-by: Wu Bo <wubo40@huawei.com>