### PR TITLE
Add iscsi-init.service

### DIFF
--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=One time configuration for iscsi.service
+ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`/usr/sbin/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'

--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -2,9 +2,9 @@
 Description=Login and scanning of iSCSI devices
 Documentation=man:iscsiadm(8) man:iscsid(8)
 Before=remote-fs.target
-After=network.target network-online.target iscsid.service
-Requires=iscsid.socket
-ConditionPathExists=/etc/iscsi/initiatorname.iscsi
+After=network.target network-online.target
+After=iscsid.service iscsi-init.service
+Requires=iscsid.socket iscsi-init.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Per Fedora Packaging Guidelines [1], initial configuration of a service
should happen in a one-off init service in order to ensure idempotency,
and not in the %post directive of the RPM spec.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1493296

[1]: https://docs.fedoraproject.org/en-US/packaging-guidelines/Initial_Service_Setup/