### PR TITLE
Fix zero length array usage, and some iscsiuio compiler issues

### DIFF
--- a/include/iscsi_if.h
+++ b/include/iscsi_if.h
@@ -841,7 +841,7 @@ struct iscsi_stats {
 	 * up to ISCSI_STATS_CUSTOM_MAX
 	 */
 	uint32_t custom_length;
-	struct iscsi_stats_custom custom[0]
+	struct iscsi_stats_custom custom[]
 		__attribute__ ((aligned (sizeof(uint64_t))));
 };
 
@@ -972,7 +972,7 @@ struct iscsi_offload_host_stats {
 	 * up to ISCSI_HOST_STATS_CUSTOM_MAX
 	 */
 	uint32_t custom_length;
-	struct iscsi_host_stats_custom custom[0]
+	struct iscsi_host_stats_custom custom[]
 		 __attribute__ ((aligned (sizeof(uint64_t))));
 };
 

--- a/iscsiuio/src/uip/ipv6.c
+++ b/iscsiuio/src/uip/ipv6.c
@@ -519,7 +519,7 @@ static void ipv6_insert_protocol_chksum(struct ipv6_hdr *ipv6)
 	 * SRC IP, DST IP, Protocol Data Length, and Next Header.
 	 */
 	sum = 0;
-	ptr = (u16_t *)&ipv6->ipv6_src;
+	ptr = (u16_t *)&ipv6->ipv6_src.addr16[0];
 
 	for (i = 0; i < sizeof(struct ipv6_addr); i++) {
 		sum += HOST_TO_NET16(*ptr);


### PR DESCRIPTION
These commits make the gcc-10 compiler happier, eliminating all but a few iscsiuio packed-vs-aligned warnings.