### PR TITLE
iscsi: fix fd leak

### DIFF
--- a/utils/fwparam_ibft/fwparam_ibft.c
+++ b/utils/fwparam_ibft/fwparam_ibft.c
@@ -463,6 +463,7 @@ fwparam_ibft(struct boot_context *context, const char *filepath)
 	if (stat(filename, &buf)!=0) {
 		fprintf(stderr, "Could not stat file %s: %s (%d)\n",
 			filename, strerror(errno), errno);
+		close(fd);
 		return -1;
 	}
 	/* And if not zero use that size */


### PR DESCRIPTION
iscsi-review/utils/fwparam_ibft/fwparam_ibft.c: line 466

Before return -1, the fd was opend and not closed which would lead
to leak fd. Fix that.
Signed-off-by: lixiaokeng<lixiaokeng@huawei.com>
Reported-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>