### PR TITLE
libopeniscsiusr: Compare with max int instead of max long

### DIFF
--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -260,7 +260,7 @@ do {\
 	_recs[_n].type = TYPE_INT_LIST; \
 	_strncpy(_recs[_n].name, _key, NAME_MAXVAL); \
 	for (unsigned int _i = 0; _i < ARRAY_LEN(_org->_name); _i++) { \
-		if (_org->_name[_i] != ~0UL) { \
+		if (_org->_name[_i] != UINT_MAX) { \
 			for (unsigned int _j = 0; _j < ARRAY_LEN(_tbl); _j++) { \
 				if (_tbl[_j].value == _org->_name[_i]) { \
 					strcat(_recs[_n].value, _tbl[_j].name); \


### PR DESCRIPTION
This compares value member of int_list_tbl struct which is of unsigned
int type.

struct int_list_tbl {
const char *name;
unsigned int value;
};

Clang compiler reports this comparison when
-Wtautological-constant-out-of-range-compare is enabled

| idbm.c:1042:2: error: result of comparison of constant 18446744073709551615 with expression of type 'unsigned int' is always true [-Werror,-Wtautological-constant-out-of-range-compare]
|         _rec_int_list(SESSION_CHAP_ALGS, recs, node, session.auth.chap_algs,
|         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| idbm.c:263:23: note: expanded from macro '_rec_int_list'
|                 if (_org->_name[_i] != ~0UL) { \
|                     ~~~~~~~~~~~~~~~ ^  ~~~~

Since max value for int can be less than unsinged long e.g. on LP64 its
better to use UINT_MAX here

Signed-off-by: Khem Raj <raj.khem@gmail.com>