### PR TITLE
iscsid: Poll timeout value to 1 minute for iscsid

### DIFF
--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1426,7 +1426,7 @@ int iscsi_sysfs_for_each_session(void *data, int *nr_found,
 	if (!info)
 		return ISCSI_ERR_NOMEM;
 
-	info->iscsid_req_tmo = -1;
+	info->iscsid_req_tmo = ISCSID_RESP_POLL_TIMEOUT;
 	n = scandir(ISCSI_SESSION_DIR, &namelist, trans_filter,
 		    alphasort);
 	if (n <= 0)

--- a/usr/iscsi_sysfs.h
+++ b/usr/iscsi_sysfs.h
@@ -34,6 +34,7 @@ struct iscsi_auth_config;
 struct flashnode_rec;
 
 #define SCSI_MAX_STATE_VALUE 32
+#define ISCSID_RESP_POLL_TIMEOUT 60000
 
 extern void free_transports(void);
 extern char *iscsi_sysfs_get_iscsi_kernel_version(void);

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -156,7 +156,7 @@ int iscsid_response(int fd, iscsiadm_cmd_e cmd, iscsiadm_rsp_t *rsp,
 		if (!err) {
 			if (poll_wait)
 				continue;
-			return ISCSI_ERR_ISCSID_NOTCONN;
+			return ISCSI_ERR_SESSION_NOT_CONNECTED;
 		} else if (err < 0) {
 			if (errno == EINTR)
 				continue;


### PR DESCRIPTION
    Description
    ===========
    This patch has the following two changes
    ------------------------------------------

    Change 1: Specify the poll timeout value to 1 minute as third parameter
    to the function iscsid_exec_req() when called from sync_session()

    Reason: Currently the poll timeout value sent sent to iscsid_response()
    from iscsid_exec_req() is "info->iscsid_req_tmo" which is -1 as set in
    "iscsi_sysfs_for_each_session()". When iscsid_response() receives this
    -1, it sets the timeout value to ISCSID_REQ_TIMEOUT (1000 ms) and also
    sets a local variable "poll_wait" to 1. There is a while loop below this
    which checks the value of "poll_wait". If "poll_wait" is set to 1, then
    it calls "continue". For sessions which are giving continuous connection
    errors (like target service stopped OR target node is shutdown OR any
    other continuous connection errors etc ...), this results in an
    indefinite while loop, as nothing will be written to the poll fd,
    resulting in further sessions not getting synced (or recovered) when the
    iscsid is restarted due to any reason (either manual restart of iscsid
    or rpm install). Poll timeout of 1 minute seems to be a reasonable value
    for the slow connections

    Change 2: Change the return error code from the function
    iscsid_response() to ISCSI_ERR_SESSION_NOT_CONNECTED when the poll times
    out and returns error 0

    Reason: Currently the iscsid_response() function returns
    ISCSI_ERR_ISCSID_NOTCONN error code in case if the poll times out and
    the poll_wait variable is 0 (i.e poll timeout sent to
    iscsid_response() was -1). Returning this error code doesn't
    seem to be correct for the following two reasons:
        a. ISCSI_ERR_ISCSID_NOTCONN should be returned only when we
           are not able to connect to iscsid but we are in iscsid_response()
           function indicating that we were able to  connect to iscsid
           successfully
        b. When ISCSI_ERR_ISCSID_NOTCONN is returned, the
           sync_session() will retry the request till 30 retries are reached. This
           causes an overlap of multiple "iscsi login task" in
           kernel and the kernel will return an error to the
           user-space indicating "Login/Text in progress. Cannot start new task.".
           This is repeated continuously which results in session not getting
           recovered even after it comes back up. Also at one point of time we
           observed that the kernel panics in "iscsi_sw_tcp_conn_set_param()" while
           trying to set the param ISCSI_PARAM_DATADGST_EN. We have a kernel fix
           for this panic which is in review for upstream