### PR TITLE
iscsid: fix logging level when starting and shutting down daemon

### DIFF
--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -301,7 +301,7 @@ static void iscsid_shutdown(void)
 	while ((pid = waitpid(0, NULL, 0) > 0))
 		log_debug(7, "cleaned up pid %d", pid);
 
-	log_warning("iscsid shutting down.");
+	log_info("iscsid shutting down.");
 	if (daemonize && log_pid >= 0) {
 		log_debug(1, "daemon stopping");
 		log_close(log_pid);

--- a/usr/log.c
+++ b/usr/log.c
@@ -448,7 +448,7 @@ int log_init(char *program_name, int size,
 			syslog(LOG_ERR, "starting logger failed");
 			exit(1);
 		} else if (pid) {
-			syslog(LOG_WARNING,
+			syslog(LOG_INFO,
 			       "iSCSI logger with pid=%d started!", pid);
 			return pid;
 		}


### PR DESCRIPTION
Some users monitor syslog by logging level. Inappropriate logging level breaks their monitoring because of false alert.
