### PR TITLE
Fix two issues in iscsid 

### DIFF
--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -451,6 +451,7 @@ int main(int argc, char *argv[])
 
 	if ((mgmt_ipc_fd = mgmt_ipc_listen()) < 0) {
 		log_close(log_pid);
+		idbm_terminate();
 		exit(ISCSI_ERR);
 	}
 
@@ -463,6 +464,8 @@ int main(int argc, char *argv[])
 			if (fd < 0) {
 				log_error("Unable to create pid file");
 				log_close(log_pid);
+				idbm_terminate();
+				close(mgmt_ipc_fd);
 				exit(ISCSI_ERR);
 			}
 		}
@@ -470,9 +473,15 @@ int main(int argc, char *argv[])
 		if (pid < 0) {
 			log_error("Starting daemon failed");
 			log_close(log_pid);
+			idbm_terminate();
+			close(mgmt_ipc_fd);
+			close(fd);
 			exit(ISCSI_ERR);
 		} else if (pid) {
 			log_info("iSCSI daemon with pid=%d started!", pid);
+			idbm_terminate();
+			close(mgmt_ipc_fd);
+			close(fd);
 			exit(0);
 		}
 

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -479,15 +479,7 @@ int main(int argc, char *argv[])
 			exit(ISCSI_ERR);
 		} else if (pid) {
 			log_info("iSCSI daemon with pid=%d started!", pid);
-			idbm_terminate();
-			close(mgmt_ipc_fd);
-			close(fd);
-			exit(0);
-		}
 
-		if (chdir("/") < 0)
-			log_debug(1, "Unable to chdir to /");
-		if (fd > 0) {
 			if (lockf(fd, F_TLOCK, 0) < 0) {
 				log_error("Unable to lock pid file");
 				log_close(log_pid);
@@ -498,13 +490,21 @@ int main(int argc, char *argv[])
 				log_close(log_pid);
 				exit(ISCSI_ERR);
 			}
-			sprintf(buf, "%d\n", getpid());
+			sprintf(buf, "%d\n", pid);
 			if (write(fd, buf, strlen(buf)) < 0) {
 				log_error("Unable to write pid file");
 				log_close(log_pid);
 				exit(ISCSI_ERR);
 			}
+
+			idbm_terminate();
+			close(mgmt_ipc_fd);
+			close(fd);
+			exit(0);
 		}
+
+		if (chdir("/") < 0)
+			log_debug(1, "Unable to chdir to /");
 		close(fd);
 
 		if ((control_fd = ipc->ctldev_open()) < 0) {


### PR DESCRIPTION
This PR fixes two issues in iscsid
1. change iscsid writing pidfile from child process to parent process to avoid systemd report error with fork mode;
2. add resource clean before process exit