### PR TITLE
RFC: Regression in 2.1.3 causes `iscsistart` to fail to login to sessions

### DIFF
--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -246,7 +246,7 @@ static int login_session(struct node_rec *rec)
 		rc = iscsid_exec_req(&req, &rsp, 0, ISCSID_REQ_TIMEOUT);
 		if (rc == 0) {
 			return rc;
-		} else if (rc == ISCSI_ERR_ISCSID_NOTCONN) {
+		} else if (rc == ISCSI_ERR_SESSION_NOT_CONNECTED) {
 			ts.tv_sec = msec / 1000;
 			ts.tv_nsec = (msec % 1000) * 1000000L;
 


### PR DESCRIPTION
In [this commit](https://github.com/open-iscsi/open-iscsi/commit/9258c8eae046d98511d92912983778ca57ba201f), which landed in 2.1.3, the method `iscsid_response` in `iscsid_req.c` changed a return code from `ISCSI_ERR_ISCSID_NOTCONN` to `ISCSI_ERR_SESSION_NOT_CONNECTED`. There are two reasons stated in the commit message and they seem legitimate. However, it seems `iscsistart` relied on the old behavior in `login_session` and it was not updated to match. This manifested in an annoying fashion. During a UEFI network boot, which invoked `iscsistart`, the initiator would open a TCP connection to the target and then a second later it would close that TCP connection without sending any data on it. The initiator would then complain with the error `initiator reported error (32 - target likely not connected)`. I believe this is because the underlying TCP transport is set to non-blocking, so the first `ep_connect` returns `EINPROGRESS`. Under normal circumstances it would eventually get resumed. However since the errant `ISCSI_ERR_SESSION_NOT_CONNECTED` error is returned out of `login_session` / `setup_session` and the child thread is killed before any progress can happen. It just so happened that on a single-core VM where I was testing, the race was reliably won and I was unable to reproduce the issue. But on real multi-core hardware I'd hit the error case every time.

I corrected that oversight and grep'd for remaining usages of the `ISCSI_ERR_ISCSID_NOTCONN`. The remaining uses all come from `ipc_connect`, which seems appropriate. Only `sync_session` seems to catch this error. I'm not familiar with the code however so someone should double check that.