### PR TITLE
Add etc/systemd/iscsi-init.service to SYSTEMDFILES Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ETCFILES = etc/iscsid.conf
 IFACEFILES = etc/iface.example
 RULESFILES = utils/50-iscsi-firmware-login.rules
 SYSTEMDFILES = etc/systemd/iscsi.service \
+			   etc/systemd/iscsi-init.service \
 			   etc/systemd/iscsid.service etc/systemd/iscsid.socket \
 			   etc/systemd/iscsiuio.service etc/systemd/iscsiuio.socket
 


### PR DESCRIPTION
iscsi-init.service is not included in the `SYSTEMDFILES` Makefile variable, causing it to be skipped when the `install_systemd` rule is executed. This causes the `iscsi` systemd service to fail on a fresh install, as it requires the `iscsi-init` service.

This PR adds `etc/systemd/iscsi-init.service` to the list of files in `SYSTEMDFILES` to correct this issue.