### PR TITLE
iscsid: Add NO_SYSTEMD to CFLAGS

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -43,6 +43,8 @@ ISCSI_LIB = -L$(TOPDIR)/libopeniscsiusr -lopeniscsiusr
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
 ifeq ($(NO_SYSTEMD),)
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libsystemd)
+else
+CFLAGS += -DNO_SYSTEMD
 endif
 PROGRAMS = iscsid iscsiadm iscsistart
 


### PR DESCRIPTION
When building with `NO_SYSTEMD=1` set the `-DNO_SYSTEMD` `CFLAG`, otherwise the `iscsid` build tries to include the systemd header and aborts:

```
iscsid.c:38:10: fatal error: systemd/sd-daemon.h: No such file or directory
```