### PR TITLE
Wants=network-online.target in iscsi.service

### DIFF
--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -5,6 +5,7 @@ Before=remote-fs.target
 After=network.target network-online.target
 After=iscsid.service iscsi-init.service
 Requires=iscsid.socket iscsi-init.service
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Setting After= without Requires= or Wants= is not enough to pull
network-online.target as a dependency.

Currently, if some other service requires network-online.target
then iscsi.service is started after network-online.target

If no any other services require network-online.target then
iscsi.service may be started before networking is working.
The latter leads to the following issues:

    iscsiadm: Could not login to [iface: default, target: XXX, portal: XXX,3260].
    iscsiadm: initiator reported error (4 - encountered connection failure)

Reference: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/