### PR TITLE
Fix iscsistart login issue when target is delayed.

### DIFF
--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -241,12 +241,25 @@ static int login_session(struct node_rec *rec)
 	/*
 	 * Need to handle race where iscsid proc is starting up while we are
 	 * trying to connect. Retry with exponential backoff, start from 50 ms.
+	 *
+	 * NOTE: another race condition can occur if the system is just coming
+	 * up, where our login request will be sent, but the login response
+	 * takes a while. In such a case, if we timeout and give up, the
+	 * login response may still show up once we give up, in which case
+	 * it seems to get iscsistart into a state where it cannot try to
+	 * login again because it thinks there's already a session. So make
+	 * sure our timeout is long enough, on each try, to give the response
+	 * a chance to show up. The old value of 1 second was not enough,
+	 * so we multiply that by 10, which seems reasonable for initial
+	 * login.
 	 */
 	for (msec = 50; msec <= 15000; msec <<= 1) {
-		rc = iscsid_exec_req(&req, &rsp, 0, ISCSID_REQ_TIMEOUT);
+		int tmo = ISCSID_REQ_TIMEOUT * 10;
+
+		rc = iscsid_exec_req(&req, &rsp, 0, tmo);
 		if (rc == 0) {
 			return rc;
-		} else if (rc == ISCSI_ERR_ISCSID_NOTCONN) {
+		} else if (rc == ISCSI_ERR_SESSION_NOT_CONNECTED) {
 			ts.tv_sec = msec / 1000;
 			ts.tv_nsec = (msec % 1000) * 1000000L;
 


### PR DESCRIPTION
Earlier commit 9258c8eae046 changed the return value fron
iscsid_response() from ISCSI_ERR_ISCSID_NOTCONN to
ISCSI_ERR_SESSION_NOT_CONNECTED in the case where no iscsi response is
received when expected.

This effected the login code in iscsistart when the target is not
completely ready at iscsi login time. This commit updates iscsistart
to expect the new error code, but fixing this uncovered another issue,
causing iscsistart logins to continue to fail if the target returned its
login response too slowly.

This commit ups the timeout time for iscsistart logins from 1 second per
try to 10 seconds per try. This is perhaps excessive, and a shorter
delay would be more appropriate, but the retry/nanosleep logic in
iscsistart meant to retry the login in such cases seems problematic in
this case, since retrying the 2nd time returns "session already exists",
and most iscsistart clients aren't prepared for the command to return a
non-zero return value.