### PR TITLE
Iscsi sessions get

### DIFF
--- a/libopeniscsiusr/libopeniscsiusr/libopeniscsiusr.h
+++ b/libopeniscsiusr/libopeniscsiusr/libopeniscsiusr.h
@@ -288,7 +288,7 @@ __DLL_EXPORT void iscsi_sessions_free(struct iscsi_session **ses,
  *	Output pointer of 'struct iscsi_session' pointer. Its memory
  *	should be freed by iscsi_session_free().
  *	If this pointer is NULL, your program will be terminated by assert.
- *	If specified iSCSI session does not exists, this pointer will be set to
+ *	If specified iSCSI session does not exist, this pointer will be set to
  *	NULL with LIBISCSI_OK returned.
  *
  * Return:

--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -127,17 +127,17 @@ int iscsi_session_get(struct iscsi_context *ctx, uint32_t sid,
 	_alloc_null_check(ctx, *se , rc, out);
 
 	if (! _file_exists(sysfs_se_dir_path)) {
-		_info(ctx, "Sysfs path '%s' does not exists",
+		_info(ctx, "Sysfs path '%s' does not exist",
 		      sysfs_se_dir_path);
 		rc = LIBISCSI_ERR_SESS_NOT_FOUND;
 	}
 	if (! _file_exists(sysfs_con_dir_path)) {
-		_info(ctx, "Sysfs path '%s' does not exists",
+		_info(ctx, "Sysfs path '%s' does not exist",
 		      sysfs_se_dir_path);
 		rc = LIBISCSI_ERR_SESS_NOT_FOUND;
 	}
 	if (rc == LIBISCSI_ERR_SESS_NOT_FOUND) {
-		_error(ctx, "Specified SID %" PRIu32, "does not exists",
+		_error(ctx, "Specified SID %" PRIu32 " does not exist",
 		       sid);
 		goto out;
 	}

--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -169,11 +169,11 @@ int _sysfs_prop_get_str(struct iscsi_context *ctx, const char *dir_path,
 			if (default_value == NULL) {
 				rc = LIBISCSI_ERR_SYSFS_LOOKUP;
 				_error(ctx, "Failed to read '%s': "
-				       "file '%s' does not exists", prop_name,
+				       "file '%s' does not exist", prop_name,
 				       file_path);
 			} else {
 				_info(ctx, "Failed to read '%s': "
-				      "file '%s' does not exists, "
+				      "file '%s' does not exist, "
 				      "using default value %s", prop_name,
 				      file_path, default_value);
 				memcpy(buff, (void *) default_value,
@@ -244,13 +244,13 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 			if (! ignore_error) {
 				rc = LIBISCSI_ERR_SYSFS_LOOKUP;
 				_error(ctx, "Failed to read '%s': "
-				       "file '%s' does not exists",
+				       "file '%s' does not exist",
 				       prop_name, file_path);
 				goto out;
 			} else {
 				_info(ctx,
 				       "Failed to read '%s': "
-				      "File '%s' does not exists, using ",
+				      "File '%s' does not exist, using ",
 				      "default value %lld",
 				      prop_name, file_path, default_value);
 				*val = default_value;


### PR DESCRIPTION
iscsiadm issues with libopeniscsiusr code returning an error when reading all session attributes from sysfs while sessions are being created and destroyed.  Reported from an OpenStack configuration.

I'm going to wait a bit and see if I can get some better testing confirmation from the original reporter, but I expect this will work.  Will merge once fix is confirmed.