### PR TITLE
Enable iscsi.service asynchronous logins, cleanup services

### DIFF
--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -2,14 +2,13 @@
 Description=Login and scanning of iSCSI devices
 Documentation=man:iscsiadm(8) man:iscsid(8)
 Before=remote-fs.target
-After=network.target network-online.target
-After=iscsid.service iscsi-init.service
+After=network-online.target iscsid.service
 Requires=iscsid.socket iscsi-init.service
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/sbin/iscsiadm -m node --loginall=automatic
+ExecStart=/sbin/iscsiadm -m node --loginall=automatic -W
 ExecStop=/sbin/iscsiadm -m node --logoutall=automatic
 ExecStop=/sbin/iscsiadm -m node --logoutall=manual
 SuccessExitStatus=21 15

--- a/etc/systemd/iscsid.service
+++ b/etc/systemd/iscsid.service
@@ -2,9 +2,10 @@
 Description=Open-iSCSI
 Documentation=man:iscsid(8) man:iscsiuio(8) man:iscsiadm(8)
 DefaultDependencies=no
-After=network.target iscsiuio.service
+After=network-online.target iscsiuio.service iscsi-init.service
 Before=remote-fs-pre.target
 Wants=remote-fs-pre.target
+Requires=iscsi-init.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Add the "-W" (no wait) flag to the iscsiadm login command in
iscsi.service, so that the service succeeds even if one or more
of the targets being logged on to is not available at startup
time.

Also, clean up the iscsi.service and iscsid.service files.