### PR TITLE
iscsid: Log error message when auth debug status is set

### DIFF
--- a/usr/login.c
+++ b/usr/login.c
@@ -624,8 +624,8 @@ check_security_stage_status(iscsi_session_t *session,
 	case AUTH_STATUS_ERROR:
 	case AUTH_STATUS_FAIL:
 	default:
-		acl_get_dbg_status(auth_client, &debug_status);
-		if (debug_status !=   AUTH_DBG_STATUS_NOT_SET)
+		if (acl_get_dbg_status(auth_client, &debug_status) == 
+			AUTH_STATUS_NO_ERROR)
 			log_error("Login authentication failed "
 				       "with target %s, %s",
 				       session->target_name,

--- a/usr/login.c
+++ b/usr/login.c
@@ -624,8 +624,8 @@ check_security_stage_status(iscsi_session_t *session,
 	case AUTH_STATUS_ERROR:
 	case AUTH_STATUS_FAIL:
 	default:
-		if (acl_get_dbg_status(auth_client, &debug_status) !=
-		    AUTH_STATUS_NO_ERROR)
+		acl_get_dbg_status(auth_client, &debug_status);
+		if (debug_status !=   AUTH_DBG_STATUS_NOT_SET)
 			log_error("Login authentication failed "
 				       "with target %s, %s",
 				       session->target_name,


### PR DESCRIPTION
Log the correct error message in /var/log/messages when the debug status is set when there is an authentication error.The change is made in check_security_stage_status() function. This issue was identified when one of the customer was trying to login to the iscsi target after configuring the mutual CHAP authentication. They set the same password for both side authentication. This is not allowed as per the code as it was returning AUTH_DBG_STATUS_PASSWD_IDENTICAL. The error logged in /var/log/messages was not obvious. This change will help to understand the correct error message so that required action can be taken.