### PR TITLE
Check ISCSI_ERR_ISCSID_NOTCONN in iscsistart login

### DIFF
--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -259,7 +259,8 @@ static int login_session(struct node_rec *rec)
 		rc = iscsid_exec_req(&req, &rsp, 0, tmo);
 		if (rc == 0) {
 			return rc;
-		} else if (rc == ISCSI_ERR_SESSION_NOT_CONNECTED) {
+		} else if (rc == ISCSI_ERR_SESSION_NOT_CONNECTED ||
+			   rc == ISCSI_ERR_ISCSID_NOTCONN) {
 			ts.tv_sec = msec / 1000;
 			ts.tv_nsec = (msec % 1000) * 1000000L;
 


### PR DESCRIPTION
In login_session() function, we need to check for error ISCSI_ERR_ISCSID_NOTCONN also. When the login command is sent to the iscsid using iscsid_exec_req(), it will try to connect to iscsid using the function ipc_connect(). If there is an issue in iscsid or if we are not able to create the socket due to some reason, then the error ISCSI_ERR_ISCSID_NOTCONN is returned. We need to retry the login command by checking the error ISCSI_ERR_ISCSID_NOTCONN.