### PR TITLE
Set default 'startup' to 'onboot' for FW nodes

### DIFF
--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -2458,6 +2458,12 @@ int idbm_add_node(node_rec_t *newrec, discovery_rec_t *drec, int overwrite)
 		rc = idbm_delete_node(&rec);
 		if (rc)
 			goto unlock;
+
+		if (drec->type == DISCOVERY_TYPE_FW) {
+			log_debug(8, "setting firmware node 'startup' to 'onboot'");
+			newrec->startup = ISCSI_STARTUP_ONBOOT;
+			newrec->conn[0].startup = ISCSI_STARTUP_ONBOOT;
+		}
 		log_debug(7, "overwriting existing record");
 	} else
 		log_debug(7, "adding new DB record");


### PR DESCRIPTION
When "iscsiadm -m discovery -t fw" is ran, nodes are
created/updated in the node DB for each firmware target
found, but the 'startup' mode values are left as 'manual',
when in fact firmware nodes are treated as if this
value is 'onboot'. So to keep the node DB in sync with
behavior, set these to 'onboot' by default. This
should *not* effect any other functionality.