### PR TITLE
iscsistart: fix null pointer deref before exit

### DIFF
--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
 	struct boot_context *context, boot_context;
 	struct sigaction sa_old;
 	struct sigaction sa_new;
-	struct user_param *param;
+	struct user_param *param, *tmp_param;
 	int control_fd, mgmt_ipc_fd, err;
 	pid_t pid;
 
@@ -556,7 +556,7 @@ int main(int argc, char *argv[])
 	mgmt_ipc_close(mgmt_ipc_fd);
 	free_initiator();
 	sysfs_cleanup();
-	list_for_each_entry(param, &user_params, list) {
+	list_for_each_entry_safe(param, tmp_param, &user_params, list) {
 		list_del(&param->list);
 		idbm_free_user_param(param);
 	}


### PR DESCRIPTION
Fixes regression caused by "open-iscsi: Clean user_param list when
process exit"  Which is a shame, as not freeing a memory at process exit
doesn't really hurt anything.

Same change as "Fix iscsiadm segfault when exiting" applied to iscsiadm.

Fixes: b532ad67d495d42026165a26515c645995d23f18
Signed-off-by: Chris Leech <cleech@redhat.com>