### PR TITLE
Add prctl(PR_SET_IO_FLUSHER) to avoid mem deadlock

### DIFF
--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 
 #include "sysdeps.h"
 #include "log.h"
@@ -384,4 +385,21 @@ int iscsi_match_target(void *data, struct session_info *info)
 				     info->persistent_address,
 				     info->persistent_port, NULL,
 				     MATCH_ANY_SID);
+}
+
+int setup_safe_io_memory(void)
+{
+	int res = 0;
+
+#ifdef	PR_SET_IO_FLUSHER
+	log_debug(3, "Setting up SAFE I/O Kernel Mem Alloc");
+	if ((res = prctl(PR_SET_IO_FLUSHER, 1)) < 0) {
+		log_error("Cannot setup safe kernel memory allocation");
+		log_debug(5, "prctl() failed, errno=%d", errno);
+	}
+#else
+	log_debug(3, "Skipping setup of SAFE I/O Kernel Mem Alloc: no PR_SET_IO_FLUSHER ioctl");
+#endif
+
+	return res;
 }

--- a/usr/iscsi_util.h
+++ b/usr/iscsi_util.h
@@ -29,4 +29,5 @@ extern char *cfg_get_string_param(char *pathname, const char *key);
 struct sockaddr_un;
 extern int setup_abstract_addr(struct sockaddr_un *addr, char *unix_sock_name);
 
+extern int setup_safe_io_memory(void);
 #endif

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -464,6 +464,12 @@ int main(int argc, char *argv[])
 	daemon_config.initiator_name = NULL;
 	daemon_config.initiator_alias = NULL;
 
+	/* this must be done before memory allocation, including socket creation */
+	if (setup_safe_io_memory() != 0) {
+		log_close(log_pid);
+		exit(ISCSI_ERR);
+	}
+
 	if ((mgmt_ipc_fd = mgmt_ipc_listen()) < 0) {
 		log_close(log_pid);
 		exit(ISCSI_ERR);


### PR DESCRIPTION
Use the new prctl(PR_SET_IO_FLUSHER, 1) system call call
o ensure that memory allocation, when interacting with our
ernel components, doesn't cause a deadlock, but only if
it is available.