### PR TITLE
iscsid: set PR_SET_IO_FLUSHER

### DIFF
--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -34,6 +34,7 @@
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/prctl.h>
 #ifndef	NO_SYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
@@ -55,6 +56,10 @@
 #include "discoveryd.h"
 #include "iscsid_req.h"
 #include "iscsi_err.h"
+
+#ifndef PR_SET_IO_FLUSHER
+#define PR_SET_IO_FLUSHER 57
+#endif
 
 /* global config info */
 struct iscsi_daemon_config daemon_config;
@@ -614,6 +619,15 @@ int main(int argc, char *argv[])
 		log_error("failed to mlockall, exiting...");
 		log_close(log_pid);
 		exit(ISCSI_ERR);
+	}
+
+	if (prctl(PR_SET_IO_FLUSHER, 1, 0, 0, 0) == -1) {
+		if (errno == EINVAL) {
+			log_info("prctl could not mark iscsid with the PR_SET_IO_FLUSHER flag, because the feature is not supported in this kernel. Will proceed, but iscsid may hang during session level recovery if memory is low.\n");
+		} else {
+			log_error("prctl could not mark iscsid with the PR_SET_IO_FLUSHER flag due to error %s\n",
+				  strerror(errno));
+		}
 	}
 
 	set_state_to_ready();


### PR DESCRIPTION
When iscsid makes syscalls that lead to memory allocations the kernel
might use GFP_KERNEL. This can lead to pages being written to iscsi
disks managed by iscsid. If we are doing a syscall to try and reconnect
the session the disk is accessed through then we could deadlock.

When in the iscsi layer we can select our GFP flags but when making
syscalls to the network layer we have to set PR_SET_IO_FLUSHER so we
use the correct GFP flags.

Signed-off-by: Mike Christie <michael.christie@oracle.com>