### PR TITLE
Handle ipv6 better

### DIFF
--- a/doc/iscsiadm.8
+++ b/doc/iscsiadm.8
@@ -35,13 +35,12 @@ iscsiadm \- open-iscsi administration utility
 .RB [ \-P
 .IR printlevel ]
 .RB [ \-I
-.IB iface\  \-t\  type\  \-p\  ip:port
-.RB [ \-l ]
-] | [
+.IR iface ]
+.RB [ \-t
+.IR  type ]
 .RB [ \-p
 .IR ip:port ]
-.RB [ \-l | \-D ]
-]
+.RB [ \-l ]
 .PP
 .B iscsiadm
 .B \-m node
@@ -473,6 +472,11 @@ Specify the \fIindex\fR of the entity to operate on.
 This option is only valid for chap and flashnode submodes of host mode.
 .SH DISCOVERY TYPES
 iSCSI defines 3 discovery types: SendTargets, SLP, and iSNS.
+.PP
+A special discovery type called
+.I fw
+(for firmware) is also supported, for discoverying firmware interfaces,
+and populating the interface database in the process.
 .TP
 .B
 SendTargets
@@ -494,6 +498,7 @@ optionally the port of the iSNS server to do discovery to.
 .TP
 .B
 fw
+Firmware mode.
 Several NICs and systems contain a mini iSCSI initiator which can be used
 for boot. To get the values used for boot the fw option can be used.
 Doing fw discovery, does not store persistent records in the node or
@@ -503,17 +508,9 @@ resource.
 Performing fw discovery will print the portals, like with other discovery
 methods. To see other settings like CHAP values and initiator settings,
 like you would in node mode, run \fIiscsiadm \-m fw\fR.
-.IP
-fw support in open-iscsi is experimental. The settings and iscsiadm
-syntax and output format may change.
 .P
-iscsiadm supports the
-.B
-iSNS (isns)
-or
-.B
-SendTargets (st)
-discovery type. An SLP implementation is under development.
+Note that the SLP implementation is under development and currently
+is not supported.
 .SH EXIT STATUS
 On success 0 is returned. On error one of the return codes below will
 be returned.

--- a/etc/iface.example
+++ b/etc/iface.example
@@ -91,6 +91,13 @@
 # example
 # iface.vlan_state = enable
 
+#
+# The IPv6 attributes require the interface file
+# be named with the string "ipv6" in it. Otherwise,
+# parsing such a file will cause errors, since IPv4
+# is otherwise assumed.
+#
+
 # OPTIONAL: iface.ipv6_linklocal
 # Specify the IPV6 Link Local Address with the
 # link local prefix of FE80::0/64
@@ -155,7 +162,7 @@
 #
 # IPV6 sample config file with neighbor discovery:
 #  BEGIN RECORD 2.0-872
-# iface.iscsi_ifacename = qla4xxx-3-1
+# iface.iscsi_ifacename = qla4xxx-3-1-ipv6
 # iface.ipaddress =
 # iface.hwaddress = 00:0e:1e:04:93:92
 # iface.transport_name = qla4xxx
@@ -182,7 +189,7 @@
 
 # Sample ipv6 config file(manual configured IPs):
 # BEGIN RECORD 2.0-872
-# iface.iscsi_ifacename = iface-new-file
+# iface.iscsi_ifacename = iface-new-file-ipv6
 # iface.ipaddress = fec0:ce00:7014:0041:1111:2222:1e04:9392
 # iface.hwaddress = 00:0e:1e:04:93:92
 # iface.transport_name = qla4xxx

--- a/include/iscsi_if.h
+++ b/include/iscsi_if.h
@@ -393,8 +393,11 @@ struct iscsi_path {
 #define ISCSI_IPV6_ROUTER_AUTOCFG_ENABLE	0x01
 #define ISCSI_IPV6_ROUTER_AUTOCFG_DISABLE	0x02
 
-#define ISCSI_IFACE_TYPE_IPV4		0x01
-#define ISCSI_IFACE_TYPE_IPV6		0x02
+/* Interface IP Type */
+enum iscsi_iface_type {
+	ISCSI_IFACE_TYPE_IPV4			= 1,
+	ISCSI_IFACE_TYPE_IPV6,
+};
 
 #define ISCSI_MAX_VLAN_ID		4095
 #define ISCSI_MAX_VLAN_PRIORITY		7

--- a/usr/iface.c
+++ b/usr/iface.c
@@ -995,6 +995,30 @@ void iface_link_ifaces(struct list_head *ifaces)
 	iface_for_each_iface(ifaces, 1, &nr_found, iface_link);
 }
 
+/*
+ * ipv6 address strings will have at least two colons
+ *
+ * NOTE: does NOT validate the IP address
+ */
+static bool ipaddr_is_ipv6(char *ipaddr)
+{
+	char *first_colon, *second_colon;
+	bool res = false;
+
+	if (ipaddr) {
+		first_colon = strchr(ipaddr, ':');
+		if (first_colon) {
+			second_colon = strchr(first_colon+1, ':');
+			if (second_colon &&
+			    (second_colon != first_colon))
+				res = true;
+		}
+	}
+	log_debug(8, "%s(%s) -> %u",
+		__FUNCTION__, ipaddr, res);
+	return res;
+}
+
 /**
  * iface_setup_from_boot_context - setup iface from boot context info
  * @iface: iface t setup
@@ -1068,9 +1092,6 @@ int iface_setup_from_boot_context(struct iface_rec *iface,
 	}
 	strcpy(iface->transport_name, t->name);
 
-	memset(iface->name, 0, sizeof(iface->name));
-	snprintf(iface->name, sizeof(iface->name), "%s.%s",
-		 iface->transport_name, context->mac);
 	strlcpy(iface->hwaddress, context->mac,
 		sizeof(iface->hwaddress));
 	strlcpy(iface->ipaddress, context->ipaddr,
@@ -1080,6 +1101,11 @@ int iface_setup_from_boot_context(struct iface_rec *iface,
 		sizeof(iface->subnet_mask));
 	strlcpy(iface->gateway, context->gateway,
 		sizeof(iface->gateway));
+	snprintf(iface->name, sizeof(iface->name), "%s.%s.%s.%u",
+		 iface->transport_name, context->mac,
+		 ipaddr_is_ipv6(iface->ipaddress) ?  "ipv6" : "ipv4",
+		 iface->iface_num);
+
 	log_debug(1, "iface " iface_fmt "", iface_str(iface));
 	return 1;
 }

--- a/usr/iface.h
+++ b/usr/iface.h
@@ -59,7 +59,7 @@ extern int iface_get_param_count(struct iface_rec *iface_primary,
 				 int iface_all);
 extern int iface_build_net_config(struct iface_rec *iface_primary,
 				  int iface_all, struct iovec *iovs);
-extern int iface_get_iptype(struct iface_rec *iface);
+extern enum iscsi_iface_type iface_get_iptype(struct iface_rec *iface);
 
 #define iface_fmt "[hw=%s,ip=%s,net_if=%s,iscsi_if=%s]"
 #define iface_str(_iface) \

--- a/utils/iscsi_offload
+++ b/utils/iscsi_offload
@@ -85,10 +85,11 @@ iscsi_macaddress_from_pcifn()
     local h
     local host
     local ifmac
+    local olemacoffset=$3
 
     ifmac=$(ip addr show dev $if | sed -n 's/ *link\/ether \(.*\) brd.*/\1/p')
     m5=$(( 0x${ifmac##*:} ))
-    m5=$(( $m5 + 1 ))
+    m5=$(( $m5 + $olemacoffset ))
     ifmac=$(printf "%s:%02x" ${ifmac%:*} $m5)
     for host in /sys/class/iscsi_host/host* ; do
 	if [ -L "$host" ] ; then
@@ -190,10 +191,7 @@ case "$driver" in
     qla*)
 	mod=qla4xxx
 	;;
-    qede)
-	mod=qede
-	;;
-    qedi)
+    qed*)
 	mod=qedi
 	;;
 esac
@@ -221,11 +219,11 @@ if [ "$mod" = "bnx2i" ] ; then
 elif [ "$mod" = "cxgb3i" ] ; then
     mac=$(iscsi_macaddress_from_pcidevice $pcipath $IFNAME)
 elif [ "$mod" = "be2iscsi" ] ; then
-    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME)
+    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 1)
 elif [ "$mod" = "qla4xxx" ] ; then
-    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME)
+    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 1)
 elif [ "$mod" = "qede" -o "$mod" = "qedi" ] ; then
-    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME)
+    mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 4)
 fi
 
 if [ -z "$mac" ] ; then


### PR DESCRIPTION
These commits fix up some of the ipv6 vs ipv4 interface logic, code that has largely been unused so far. Testing done on several types of offload cards using IPv6 and IPv4.

The externally-visable difference will be that interface files created by iscsiadm will generally be named, now, ending in "ipv4.N" or "ipv6.N", where "N" is the interface number (generally 0).