### PR TITLE
[old] iscsistart: Fix iscsistart timeout during login session

### DIFF
--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -254,7 +254,7 @@ static int login_session(struct node_rec *rec)
 	 * login.
 	 */
 	for (msec = 50; msec <= 15000; msec <<= 1) {
-		int tmo = ISCSID_REQ_TIMEOUT * 10;
+		int tmo = ISCSID_REQ_TIMEOUT * 60;
 
 		rc = iscsid_exec_req(&req, &rsp, 0, tmo);
 		if (rc == 0) {


### PR DESCRIPTION
When iscsistart places a login request during boot, if it gets timeout
and response receive after it. It triggers "connection1:0: detected conn
error (1011)", since in userspace nobody is listening.

On OL6, it has been observed where iscsid is not part of initramfs.

During boot, iscsistart forks and child process used as placing a request whereas
parent wait in event loop.

In the child, login_seesion places login request, and request gets
timed-out then parent also exit. If it receive response for timed-out
request and during that time no parent is listening to it then it will
error as 1011.

This patch is to increase tmo for iscsistart login request to x6. This
patch has been tested some intesive workload and helps resolve the
issue.

Signed-off-by: Jitendra Khasdev <jitendra.khasdev@oracle.com>