### PR TITLE
iscsistart: Fix iscsistart timeout during login session

### DIFF
--- a/doc/iscsistart.8
+++ b/doc/iscsistart.8
@@ -51,6 +51,10 @@ Bring up the network as specified by iBFT or OF
 .BI [-f|--fwparam_print]
 Print the iBFT or OF info to STDOUT
 .TP
+.TP
+.BI [-l, --login_timeout]
+Set initial login request timeout
+.TP
 .BI [-P|--param=]\fINAME=VALUE\fP
 Set the parameter with the name NAME to VALUE. NAME is one of the settings
 in the node record or iscsid.conf. Multiple params can be passed in.

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -65,7 +65,7 @@ static char program_name[] = "iscsistart";
 /* used by initiator */
 extern struct iscsi_ipc *ipc;
 
-static int login_req_timeout = 10;
+static int login_req_timeout = 10000;
 
 static struct option const long_options[] = {
 	{"initiatorname", required_argument, NULL, 'i'},
@@ -258,7 +258,7 @@ static int login_session(struct node_rec *rec)
 	 * login.
 	 */
 	for (msec = 50; msec <= 15000; msec <<= 1) {
-		int tmo = ISCSID_REQ_TIMEOUT * login_req_timeout;
+		int tmo = login_req_timeout;
 
 		rc = iscsid_exec_req(&req, &rsp, 0, tmo);
 		if (rc == 0) {

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -65,6 +65,8 @@ static char program_name[] = "iscsistart";
 /* used by initiator */
 extern struct iscsi_ipc *ipc;
 
+static int login_req_timeout = 10;
+
 static struct option const long_options[] = {
 	{"initiatorname", required_argument, NULL, 'i'},
 	{"targetname", required_argument, NULL, 't'},
@@ -79,6 +81,7 @@ static struct option const long_options[] = {
 	{"fwparam_connect", no_argument, NULL, 'b'},
 	{"fwparam_network", no_argument, NULL, 'N'},
 	{"fwparam_print", no_argument, NULL, 'f'},
+	{"login_timeout", required_argument, NULL, 'l'},
 	{"param", required_argument, NULL, 'P'},
 	{"help", no_argument, NULL, 'h'},
 	{"version", no_argument, NULL, 'v'},
@@ -107,6 +110,7 @@ Open-iSCSI initiator.\n\
   -b, --fwparam_connect    create a session to the target using iBFT or OF\n\
   -N, --fwparam_network    bring up the network as specified by iBFT or OF\n\
   -f, --fwparam_print      print the iBFT or OF info to STDOUT \n\
+  -l, --login_timeout      set login request timeout \n\
   -P, --param=NAME=VALUE   set parameter with the name NAME to VALUE\n\
   -h, --help               display this help and exit\n\
   -v, --version            display version and exit\n\
@@ -254,7 +258,7 @@ static int login_session(struct node_rec *rec)
 	 * login.
 	 */
 	for (msec = 50; msec <= 15000; msec <<= 1) {
-		int tmo = ISCSID_REQ_TIMEOUT * 10;
+		int tmo = ISCSID_REQ_TIMEOUT * login_req_timeout;
 
 		rc = iscsid_exec_req(&req, &rsp, 0, tmo);
 		if (rc == 0) {
@@ -381,7 +385,7 @@ int main(int argc, char *argv[])
 
 	sysfs_init();
 
-	while ((ch = getopt_long(argc, argv, "P:i:t:g:a:p:d:u:w:U:W:bNfvh",
+	while ((ch = getopt_long(argc, argv, "P:i:t:g:a:p:d:u:w:l:U:W:bNfvh",
 				 long_options, &longindex)) >= 0) {
 		switch (ch) {
 		case 'i':
@@ -460,6 +464,9 @@ int main(int argc, char *argv[])
 
 			fw_free_targets(&targets);
 			exit(0);
+		case 'l':
+			login_req_timeout = atoi(optarg);
+			break;
 		case 'P':
 			err = parse_param(optarg);
 			if (err)


### PR DESCRIPTION
When iscsistart places a login request during boot, if it gets timeout
and response receive after it. It triggers "connection1:0: detected conn
error (1011)", since in userspace nobody is listening.

On OL6, it has been observed where iscsid is not part of initramfs.

During boot, iscsistart forks and child process used as placing a request whereas
parent wait in event loop.

In the child, login_seesion places login request, and request gets
timed-out then parent also exit. If it receive response for timed-out
request and during that time no parent is listening to it then it will
error as 1011.

This patch adds an additional option to increase tmo for login request
timeout. This patch has been tested some intesive workload by increase it as 6x
and helps resolve the issue.

Signed-off-by: Jitendra Khasdev <jitendra.khasdev@oracle.com>