### PR TITLE
Fix compiler error introduced with recent IPv6 commit.

### DIFF
--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -996,7 +996,7 @@ static void _idbm_node_rec_link(struct iscsi_node *node, struct idbm_rec *recs, 
 
 	/* use the interface name passed in, if any */
 	if (iface_name)
-		strncpy((*node).iface.name, iface_name, ISCSI_MAX_IFACE_LEN);
+		strncpy((*node).iface.name, iface_name, ISCSI_MAX_IFACE_LEN-1);
 
 	/*
 	 * Note: because we do not add the iface.iscsi_ifacename to


### PR DESCRIPTION
Commit 76350316de38 ("Handle IPv6 interfaces correctly.") added
a string copy that creates this gcc-11 error message:

> gcc-11 -O2 -g -Wall -Werror -Wextra -fvisibility=hidden -fPIC -I/usr/include/kmod    -c -o idbm.o idbm.c
> idbm.c: In function ‘_idbm_node_rec_link’:
> idbm.c:999:17: error: ‘strncpy’ specified bound 65 equals destination size [-Werror=stringop-truncation]
>   999 |                 strncpy((*node).iface.name, iface_name, ISCSI_MAX_IFACE_LEN);
>       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

So copy one less character, maximum.