### PR TITLE
Remove dependences from iscsi-init.service

### DIFF
--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=One time configuration for iscsi.service
 ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Since iscsid.service depends on it but disables
default dependencies, iscsi-init.service must
also disable default dependencies, or a dependency
loop can be created.