### PR TITLE
Use "sbindir" for path in systemd service files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ install_udev_rules:
 install_systemd:
 	$(INSTALL) -d $(DESTDIR)$(systemddir)
 	$(INSTALL) -m 644 $(SYSTEMDFILES) $(DESTDIR)/$(systemddir)
+	for f in $(SYSTEMDFILES); do \
+		p=$(DESTDIR)/$(systemddir)/system/$${f##*/}; \
+		sed -i -e 's:@SBINDIR@:$(sbindir):' $$p; \
+	done
 
 install_programs:  $(PROGRAMS) $(SCRIPTS)
 	$(INSTALL) -d $(DESTDIR)$(sbindir)

--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -6,4 +6,4 @@ DefaultDependencies=no
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`/usr/sbin/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'
+ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`@SBINDIR@/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'

--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -8,9 +8,9 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/sbin/iscsiadm -m node --loginall=automatic -W
-ExecStop=/sbin/iscsiadm -m node --logoutall=automatic
-ExecStop=/sbin/iscsiadm -m node --logoutall=manual
+ExecStart=@SBINDIR@/iscsiadm -m node --loginall=automatic -W
+ExecStop=@SBINDIR@/iscsiadm -m node --logoutall=automatic
+ExecStop=@SBINDIR@/iscsiadm -m node --logoutall=manual
 SuccessExitStatus=21 15
 RemainAfterExit=true
 

--- a/etc/systemd/iscsid.service
+++ b/etc/systemd/iscsid.service
@@ -10,7 +10,7 @@ Requires=iscsi-init.service
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=/sbin/iscsid -f
+ExecStart=@SBINDIR@/iscsid -f
 KillMode=mixed
 Restart=on-failure
 

--- a/etc/systemd/iscsiuio.service
+++ b/etc/systemd/iscsiuio.service
@@ -12,7 +12,7 @@ Wants=remote-fs-pre.target
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=/sbin/iscsiuio -f
+ExecStart=@SBINDIR@/iscsiuio -f
 KillMode=mixed
 Restart=on-failure
 


### PR DESCRIPTION
Use a variable for the sbin directory where executables
go in our systemd unit files, so that the files can
be configured, during installation, to have the
correct path, instead of just hard-coding these paths.

Now "make sbindir=/SOME/PATH ..." works correctly for
different paths.