### PR TITLE
Fix iscsi-init so that it runs when root writable

### DIFF
--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -2,6 +2,7 @@
 Description=One time configuration for iscsi.service
 ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
 DefaultDependencies=no
+After=root.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
A recent commit, 432bbf979ee6 ("Remove dependences
from iscsi-init.service") removed DefaultDependencies from
iscsi-init.service, but that now means it can run so
early that the root disc is not yet writable, rendering
it useless, since it can't create the initiatorname.iscsi
file. This change tells it to wait until root is writable
to run.