### PR TITLE
ipc: Introduce iscsid_uniq_id to avoid residual command being executed

### DIFF
--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -448,6 +448,9 @@ int main(int argc, char *argv[])
 	if (log_pid < 0)
 		exit(ISCSI_ERR);
 
+	if (mgmt_init_iscsid_uniq_id())
+		exit(ISCSI_ERR);
+
 	/* do not allow ctrl-c for now... */
 	sa_new.sa_handler = catch_signal;
 	sigemptyset(&sa_new.sa_mask);

--- a/usr/mgmt_ipc.h
+++ b/usr/mgmt_ipc.h
@@ -46,6 +46,7 @@ typedef enum iscsiadm_cmd {
 	MGMT_IPC_NOTIFY_DEL_NODE	= 17,
 	MGMT_IPC_NOTIFY_ADD_PORTAL	= 18,
 	MGMT_IPC_NOTIFY_DEL_PORTAL	= 19,
+	MGMT_IPC_GET_ISCSID_UNIQ_ID	= 20,
 
 	__MGMT_IPC_MAX_COMMAND
 } iscsiadm_cmd_e;
@@ -54,6 +55,7 @@ typedef enum iscsiadm_cmd {
 typedef struct iscsiadm_req {
 	iscsiadm_cmd_e command;
 	uint32_t payload_len;
+	uint32_t iscsid_uniq_id;
 
 	union {
 		/* messages */
@@ -86,6 +88,7 @@ typedef struct iscsiadm_rsp {
 	int err;	/* ISCSI_ERR value */
 
 	union {
+		uint32_t iscsid_uniq_id;
 #define MGMT_IPC_GETSTATS_BUF_MAX	(sizeof(struct iscsi_uevent) + \
 					sizeof(struct iscsi_stats) + \
 					sizeof(struct iscsi_stats_custom) * \
@@ -110,6 +113,7 @@ struct queue_task;
 typedef int mgmt_ipc_fn_t(struct queue_task *);
 
 struct queue_task;
+int mgmt_init_iscsid_uniq_id(void);
 void mgmt_ipc_write_rsp(struct queue_task *qtask, int err);
 int mgmt_ipc_listen(void);
 int mgmt_ipc_systemd(void);


### PR DESCRIPTION
systemd would listen on ISCSIADM_ABSTRACT_NAMESPACE if iscsid.socket is started.
In this case, if iscsid exit with some iscsiadm_req_t requests unhandled, these
requests would not been cleared. When iscsid starts again, it would get these
residual requests and execute them.

It is easy to recurrent above phenomenon by following steps:

systemctl start iscsid.socket
systemctl start iscsid.service
killall -19 iscsid
systemctl restart iscsid

This PR fix above phenomenon by introducing check mechanism. Each iscsid has
a unique id, this unique id would be used to check if the requests should be
handled.