### PR TITLE
Fix iscsi-gen-initiatorname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ systemddir = $(prefix)/lib/systemd/system
 
 MANPAGES = doc/iscsid.8 doc/iscsiadm.8 doc/iscsi_discovery.8 \
 		iscsiuio/docs/iscsiuio.8 doc/iscsi_fw_login.8 doc/iscsi-iname.8 \
-		doc/iscsistart.8
+		doc/iscsistart.8 doc/iscsi-gen-initiatorname.8
 PROGRAMS = usr/iscsid usr/iscsiadm utils/iscsi-iname iscsiuio/src/unix/iscsiuio \
 		   usr/iscsistart
 SCRIPTS = utils/iscsi_discovery utils/iscsi_fw_login utils/iscsi_offload \

--- a/doc/iscsi-gen-initiatorname.8
+++ b/doc/iscsi-gen-initiatorname.8
@@ -1,0 +1,36 @@
+.TH ISCSI_GEN_INITIATORNAME 8 "Dec 2021" "" "Linux Administrator's Manual"
+.SH NAME
+iscsi-gen-initiatorname \- smart iSCSI initiator name generation tool
+.SH SYNOPSIS
+.BI iscsi-gen-initiatorname
+[OPTIONS]
+.SH "DESCRIPTION"
+.B iscsi-gen-initiatorname
+generates a unique iSCSI node name on every invocation. If
+iBFT is in use, the iBFT-registered initiator name will be used.
+.P
+If there is an existing initiator name, it will not be overwritten
+unless the \fB-f\fP option is supplied.
+.SH OPTIONS
+.TP
+.BI [-h]
+Display a help message and exit.
+.TP
+.BI [-f]
+Force overwrite of existing initiator name, if present.
+.TP
+.BI [-p] \fIIQN-PREFIX\fP
+Use \fIIQN-PREFIX\fP as the prefix to the IQN generated,
+instead of the default of \fBiqn.1996-04.de.suse:01\fP.
+.SH FILES
+.TP
+/etc/iscsi/initiatorname.iscsi
+The file containing the initiator name. Do not edit manually.
+.SH "SEE ALSO"
+.BR iscsi-iname (8)
+.SH AUTHORS
+Open-iSCSI project <http://www.open-iscsi.com/>
+.br
+Hannes Reinecke <hare@suse.de>
+.br
+Lee Duncan <lduncan@suse.com>

--- a/utils/iscsi-gen-initiatorname
+++ b/utils/iscsi-gen-initiatorname
@@ -10,7 +10,7 @@
 
 NAME="$0"
 INAME_FILE="/etc/iscsi/initiatorname.iscsi"
-IQN_BASE="iqn.1996-04.de.suse:01"
+IQN_PREFIX="iqn.1996-04.de.suse:01"
 
 usage_and_exit()
 {
@@ -20,15 +20,15 @@ usage_and_exit()
     echo "Where OPTIONS are from:"
     echo "   -h          print usage and exit"
     echo "   -f          overwrite existing initiator name, if any"
-    echo "   -b IQN-BASE use IQN-BASE for the IQN generated (default $IQN_BASE)"
+    echo "   -p IQN-PRE  set the prefix for the IQN generated (default $IQN_PREFIX)"
     exit $xit_val
 }
 
-while getopts "hfb:" o ; do
+while getopts "hfp:" o ; do
     case "${o}" in
 	h) usage_and_exit 0 ;;
 	f) FORCE=1 ;;
-	b) IQN_BASE=${OPTARG} ;;
+	p) IQN_PREFIX=${OPTARG} ;;
 	?) usage_and_exit 1 ;;
     esac
 done
@@ -94,7 +94,7 @@ if [ ! -f $INAME_FILE ] ; then
 ## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.
 EOF
     # create a unique initiator name using iscsi-iname
-    INAME=$(@SBINDIR@/iscsi-iname -p "$IQN_BASE")
+    INAME=$(@SBINDIR@/iscsi-iname -p "$IQN_PREFIX")
     echo "InitiatorName=$INAME" >> $INAME_FILE
     chmod 0600 $INAME_FILE
 fi

--- a/utils/iscsi-gen-initiatorname
+++ b/utils/iscsi-gen-initiatorname
@@ -8,23 +8,47 @@
 # This script is licensed under the GPL.
 #
 
-if [ "$1" ] ; then
-    if [ "$1" = "-f" ] ; then
-	FORCE=1
-    else
-	echo "Invalid option $1"
-	echo "Usage: $0 [-f]"
-	exit 1
-    fi
+NAME="$0"
+INAME_FILE="/etc/iscsi/initiatorname.iscsi"
+IQN_BASE="iqn.1996-04.de.suse:01"
+
+usage_and_exit()
+{
+    xit_val=$1
+
+    echo "Usage: $NAME [OPTIONS] -- generate an iSCSI initiatorname"
+    echo "Where OPTIONS are from:"
+    echo "   -h          print usage and exit"
+    echo "   -f          overwrite existing initiator name, if any"
+    echo "   -b IQN-BASE use IQN-BASE for the IQN generated (default $IQN_BASE)"
+    exit $xit_val
+}
+
+while getopts "hfb:" o ; do
+    case "${o}" in
+	h) usage_and_exit 0 ;;
+	f) FORCE=1 ;;
+	b) IQN_BASE=${OPTARG} ;;
+	?) usage_and_exit 1 ;;
+    esac
+done
+shift $(($OPTIND-1))
+
+if [ "$#" -gt 0 ] ; then
+    echo "Invalid argument(s): $*"
+    usage_and_exit
 fi
 
+# use the iBFT initiator name, if present
 if [ -d /sys/firmware/ibft/initiator ] ; then
     read iSCSI_INITIATOR_NAME < /sys/firmware/ibft/initiator/initiator-name
 fi
 
-if [ -f /etc/iscsi/initiatorname.iscsi -a -z "$FORCE" ] ; then
+# if we have an iBFT initiator name and an initiator name
+# file, they had better match, unless "force" is set
+if [ -f $INAME_FILE -a -z "$FORCE" ] ; then
     if [ "$iSCSI_INITIATOR_NAME" ] ; then
-	eval $(cat /etc/iscsi/initiatorname.iscsi | sed -e '/^#/d')
+	eval $(cat $INAME_FILE | sed -e '/^#/d')
 	if [ "$iSCSI_INITIATOR_NAME" != "$InitiatorName" ] ; then
 	    echo "iSCSI Initiatorname from iBFT is different from the current setting."
 	    echo "Please call '@SBINDIR@/iscsi-gen-initiatorname -f' to update the iSCSI Initiatorname."
@@ -33,10 +57,12 @@ if [ -f /etc/iscsi/initiatorname.iscsi -a -z "$FORCE" ] ; then
     fi
 fi
 
+# if we have an initiator name from iBFT or from
+# an existing initiator name file, use it
 if [ "$iSCSI_INITIATOR_NAME" ] ; then
-    cat << EOF >> /etc/iscsi/initiatorname.iscsi
-##
-## /etc/iscsi/iscsi.initiatorname
+    echo "##" > $INAME_FILE || exit 1
+    echo "## $INAME_FILE" >> $INAME_FILE
+    cat << EOF >> $INAME_FILE
 ##
 ## iSCSI Initiatorname taken from iBFT BIOS tables.
 ##
@@ -48,14 +74,16 @@ if [ "$iSCSI_INITIATOR_NAME" ] ; then
 ## @SBINDIR@/iscsi-gen-initiatorname -f
 ## to recreate an updated version of this file.
 ##
-InitiatorName=$iSCSI_INITIATOR_NAME
 EOF
+    echo "InitiatorName=$iSCSI_INITIATOR_NAME" >> $INAME_FILE
+    chmod 0600 $INAME_FILE
 fi
 
-if [ ! -f /etc/iscsi/initiatorname.iscsi ] ; then
-    cat << EOF >> /etc/iscsi/initiatorname.iscsi
-##
-## /etc/iscsi/iscsi.initiatorname
+# if we still do not have an initiator name, create one
+if [ ! -f $INAME_FILE ] ; then
+    echo "##" > $INAME_FILE || exit 1
+    echo "## $INAME_FILE" >> $INAME_FILE
+    cat << EOF >> $INAME_FILE
 ##
 ## Default iSCSI Initiatorname.
 ##
@@ -65,9 +93,9 @@ if [ ! -f /etc/iscsi/initiatorname.iscsi ] ; then
 ## may reject this initiator.  The InitiatorName must be unique
 ## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.
 EOF
-	ISSUEDATE="1996-04"
-	INAME=$(@SBINDIR@/iscsi-iname -p iqn.$ISSUEDATE.de.suse:01)
-	printf "InitiatorName=$INAME\n"  >>/etc/iscsi/initiatorname.iscsi
-	chmod 0600 /etc/iscsi/initiatorname.iscsi
+    # create a unique initiator name using iscsi-iname
+    INAME=$(@SBINDIR@/iscsi-iname -p "$IQN_BASE")
+    echo "InitiatorName=$INAME" >> $INAME_FILE
+    chmod 0600 $INAME_FILE
 fi
 


### PR DESCRIPTION
Fix the "iscsi-gen-initiatorname" script. This started because it ignored the error when the initiator name file was read-only, but I decided to clean up as much of the command as I could.

I also added the ability to set the IQN prefix, instead of using the "SUSE" default, so that other distros could use this script, if they wish.