### PR TITLE
iscsistart fix and timeout cleanup

### DIFF
--- a/include/iscsi_err.h
+++ b/include/iscsi_err.h
@@ -70,6 +70,8 @@ enum iscsi_error_list {
 	ISCSI_ERR_CHILD_TERMINATED	= 31,
 	/* session likely not connected */
 	ISCSI_ERR_SESSION_NOT_CONNECTED = 32,
+	/* iscsid request timed out */
+	ISCSI_ERR_REQ_TIMEDOUT = 33,
 
 	/* Always last. Indicates end of error code space */
 	ISCSI_MAX_ERR_VAL,

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -141,12 +141,7 @@ int iscsid_response(int fd, iscsiadm_cmd_e cmd, iscsiadm_rsp_t *rsp,
 	size_t len = sizeof(*rsp);
 	int iscsi_err = ISCSI_ERR_ISCSID_COMM_ERR;
 	int err;
-	int poll_wait = 0;
 
-	if (timeout == -1) {
-		timeout = ISCSID_REQ_TIMEOUT;
-		poll_wait = 1;
-	}
 	while (len) {
 		struct pollfd pfd;
 
@@ -154,8 +149,6 @@ int iscsid_response(int fd, iscsiadm_cmd_e cmd, iscsiadm_rsp_t *rsp,
 		pfd.events = POLLIN;
 		err = poll(&pfd, 1, timeout);
 		if (!err) {
-			if (poll_wait)
-				continue;
 			return ISCSI_ERR_SESSION_NOT_CONNECTED;
 		} else if (err < 0) {
 			if (errno == EINTR)

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -149,7 +149,7 @@ int iscsid_response(int fd, iscsiadm_cmd_e cmd, iscsiadm_rsp_t *rsp,
 		pfd.events = POLLIN;
 		err = poll(&pfd, 1, timeout);
 		if (!err) {
-			return ISCSI_ERR_SESSION_NOT_CONNECTED;
+			return ISCSI_ERR_REQ_TIMEDOUT;
 		} else if (err < 0) {
 			if (errno == EINTR)
 				continue;


### PR DESCRIPTION
This fixes a bug where iscsistart would exit before we've waited for the login to complete or fail. It also cleans up some related code.

This is a followup to:

https://github.com/open-iscsi/open-iscsi/pull/275