### PR TITLE
Speed up iscsid resync operation

### DIFF
--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -2017,8 +2017,13 @@ iscsi_sync_session(node_rec_t *rec, queue_task_t *qtask, uint32_t sid)
 	if (err)
 		goto destroy_session;
 
+	/*
+	 * The caller only cares we have rebuilt our state, and can process
+	 * errors from the kernel and new commands like logout, so send the
+	 * response now.
+	 */
 	qtask->rsp.command = MGMT_IPC_SESSION_SYNC;
-	session->conn[0].login_qtask = qtask;
+	mgmt_ipc_write_rsp(qtask, ISCSI_SUCCESS);
 
 	log_debug(3, "Started sync iSCSI session %d", session->id);
 	session_conn_reopen(&session->conn[0], STOP_CONN_RECOVER);

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -143,7 +143,6 @@ typedef struct iscsi_login_context {
 	int timeout;
 	int final;
 	enum iscsi_login_status ret;
-	struct queue_task *qtask;
 } iscsi_login_context_t;
 
 struct iscsi_session;
@@ -156,11 +155,13 @@ typedef struct iscsi_conn {
 	struct iscsi_session *session;
 	iscsi_login_context_t login_context;
 	struct iscsi_ev_context *recv_context;
-	struct queue_task *logout_qtask;
 	char data[ISCSI_DEF_MAX_RECV_SEG_LEN];
 	char host[NI_MAXHOST];	/* scratch */
 	enum iscsi_conn_state state;
 	int userspace_nop;
+
+	struct queue_task *login_qtask;
+	struct queue_task *logout_qtask;
 
 	struct timeval initial_connect_time;
 	actor_t login_timer;
@@ -291,7 +292,6 @@ typedef struct iscsi_session {
 	/* connection reopens during recovery */
 	int reopen_cnt;
 	int reopen_max;
-	queue_task_t reopen_qtask;
 	iscsi_session_r_stage_e r_stage;
 	uint32_t replacement_timeout;
 
@@ -299,12 +299,6 @@ typedef struct iscsi_session {
 	int tgt_reset_timeout;
 	int lu_reset_timeout;
 	int abort_timeout;
-
-	/*
-	 * used for hw and sync up to notify caller that the operation
-	 * is complete
-	 */
-	queue_task_t *notify_qtask;
 } iscsi_session_t;
 
 #define	INVALID_SESSION_ID	(uint32_t)-1

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1582,6 +1582,17 @@ int iscsi_sysfs_get_session_state(char *state, int sid)
 	return 0;
 }
 
+int iscsi_sysfs_get_conn_state(char *state, int sid)
+{
+	char id[NAME_SIZE];
+
+	snprintf(id, sizeof(id), ISCSI_CONN_ID, sid);
+	if (sysfs_get_str(id, ISCSI_CONN_SUBSYS, "state", state,
+			  SCSI_MAX_STATE_VALUE))
+		return ISCSI_ERR_SYSFS_LOOKUP;
+	return 0;
+}
+
 int iscsi_sysfs_get_host_state(char *state, int host_no)
 {
 	char id[NAME_SIZE];
@@ -1846,6 +1857,20 @@ int iscsi_sysfs_get_exp_statsn(int sid)
 		exp_statsn = 0;
 	}
 	return exp_statsn;
+}
+
+int iscsi_sysfs_conn_needs_cleanup(int sid)
+{
+	char id[NAME_SIZE];
+	int needs_cleanup;
+
+	snprintf(id, sizeof(id), ISCSI_CONN_ID, sid);
+
+	if (sysfs_get_int(id, ISCSI_CONN_SUBSYS, "needs_cleanup",
+			  &needs_cleanup))
+		return -1;
+
+	return needs_cleanup;
 }
 
 int iscsi_sysfs_session_supports_nop(int sid)

--- a/usr/iscsi_sysfs.h
+++ b/usr/iscsi_sysfs.h
@@ -91,9 +91,11 @@ extern void iscsi_sysfs_get_negotiated_conn_conf(int sid,
 				struct iscsi_conn_operational_config *conf);
 extern pid_t iscsi_sysfs_scan_host(int hostno, int async, int autoscan);
 extern int iscsi_sysfs_get_session_state(char *state, int sid);
+extern int iscsi_sysfs_get_conn_state(char *state, int sid);
 extern int iscsi_sysfs_get_host_state(char *state, int host_no);
 extern int iscsi_sysfs_get_device_state(char *state, int host_no, int target,
 					int lun);
+extern int iscsi_sysfs_conn_needs_cleanup(int sid);
 extern int iscsi_sysfs_get_exp_statsn(int sid);
 extern void iscsi_sysfs_set_queue_depth(void *data, int hostno, int target,
 					int lun);


### PR DESCRIPTION
Perform the iscsid session resync operations in parallel and do not wait for the relogin return value.

note:

These patches were made over

https://github.com/open-iscsi/open-iscsi/pull/291

and include those patches.