### PR TITLE
libopeniscsiusr: extend sysfs ignore_error to include EINVAL

### DIFF
--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -240,7 +240,7 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 
 	errno_save = sysfs_read_file(file_path, buff, _INT32_STR_MAX_LEN);
 	if (errno_save != 0) {
-		if (errno_save == ENOENT) {
+		if (errno_save == ENOENT || errno_save == EINVAL) {
 			if (! ignore_error) {
 				rc = LIBISCSI_ERR_SYSFS_LOOKUP;
 				_error(ctx, "Failed to read '%s': "


### PR DESCRIPTION
The kernel change
"e746f3451ec7 scsi: iscsi: Fix iface sysfs attr detection"
fixed an apparently very-long-standing issue blocking iface attribute
visibility in sysfs.

With that fixed, and networking configuration for the iface now being
readable from sysfs, iscsiadm is showing errors when be2iscsi (and
probably qla4xxx from looking at the code) expose VLAN attributes but
don't have a VLAN configured.  Both drivers then return EINVAL on a read
to vlan_id or vlan_priority.

iSCSI ERROR: Error when reading '/sys/class/iscsi_iface/ipv4-iface-17-0/vlan_id': 22 # sysfs.c:iscsi_sysfs_prop_get_ll():282
iSCSI ERROR: Error when reading '/sys/class/iscsi_iface/ipv4-iface-17-0/vlan_priority': 22 # sysfs.c:iscsi_sysfs_prop_get_ll():282

This change makes the libopeniscsiusr code ignore a read return of
EINVAL when ignore_error is set, treating it the same as a non-existent
sysfs file for optional attributes.

Signed-off-by: Chris Leech <cleech@redhat.com>