### PR TITLE
iscsi_err: Add iscsid request timed out error messages

### DIFF
--- a/usr/iscsi_err.c
+++ b/usr/iscsi_err.c
@@ -57,6 +57,7 @@ static char *iscsi_err_msgs[] = {
 	/* 30 */ "unknown discovery type",
 	/* 31 */ "child process terminated",
 	/* 32 */ "target likely not connected",
+	/* 33 */ "iscsid request timed out",
 };
 
 char *iscsi_err_to_str(int err)


### PR DESCRIPTION
Commit 67eb8b2 added error code ISCSI_ERR_REQ_TIMEOUT.
While did not update array iscsi_error_list which referenced
in iscsi_err_to_str(). Which would access a invalid memory with
when variable of iscsi_err_to_str() is ISCSI_ERR_REQ_TIMEOUT.