### PR TITLE
Fix wrong install_systemd destination path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ mandir = $(prefix)/share/man
 etcdir = /etc
 initddir = $(etcdir)/init.d
 rulesdir = $(etcdir)/udev/rules.d
-systemddir = $(prefix)/lib/systemd/system
+systemddir = $(prefix)/lib/systemd
 
 MANPAGES = doc/iscsid.8 doc/iscsiadm.8 doc/iscsi_discovery.8 \
 		iscsiuio/docs/iscsiuio.8 doc/iscsi_fw_login.8 doc/iscsi-iname.8 \


### PR DESCRIPTION
systemd files should be installed to path "/usr/lib/systemd/system", 
while previous implement installs these files to "/usr/lib/systemd/system/system".

Following error would reported by systemd when start iscsid.service:
```
root@fedora ~:# systemctl status iscsid.service 
Unit iscsid.service could not be found.
```

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>