### PR TITLE
Make session and connect log helpful to locate problem

### DIFF
--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "actor.h"
 #include "list.h"
+#include "log.h"
 
 #define ISCSI_CONFIG_ROOT	"/etc/iscsi/"
 
@@ -44,6 +45,46 @@
 #endif
 #define LOCK_FILE		LOCK_DIR"/lock"
 #define LOCK_WRITE_FILE		LOCK_DIR"/lock.write"
+
+#define conn_info(conn, fmt, ...)				\
+do {								\
+	if (conn->session == NULL) { 				\
+		log_info(fmt, ##__VA_ARGS__);			\
+		break;						\
+	}							\
+	log_info("connection%d:%d " fmt,			\
+		   conn->session->id, conn->id, ##__VA_ARGS__);	\
+} while(0)
+
+#define conn_warn(conn, fmt, ...)				\
+do {								\
+	if (conn->session == NULL) { 				\
+		log_warning(fmt, ##__VA_ARGS__);		\
+		break;						\
+	}							\
+	log_warning("connection%d:%d " fmt,			\
+		   conn->session->id, conn->id, ##__VA_ARGS__);	\
+} while(0)
+
+#define conn_error(conn, fmt, ...)				\
+do {								\
+	if (conn->session == NULL) { 				\
+		log_error(fmt, ##__VA_ARGS__);			\
+		break;						\
+	}							\
+	log_error("connection%d:%d " fmt,			\
+		   conn->session->id, conn->id, ##__VA_ARGS__);	\
+} while(0)
+
+#define conn_debug(level, conn, fmt, ...)			\
+do {								\
+	if (conn->session == NULL) { 				\
+		log_debug(level, fmt, ##__VA_ARGS__);		\
+		break;						\
+	}							\
+	log_debug(level, "connection%d:%d " fmt,		\
+		   conn->session->id, conn->id, ##__VA_ARGS__);	\
+} while(0)
 
 typedef enum iscsi_session_r_stage_e {
 	R_STAGE_NO_CHANGE,

--- a/usr/mgmt_ipc.c
+++ b/usr/mgmt_ipc.c
@@ -411,8 +411,12 @@ mgmt_ipc_write_rsp(queue_task_t *qtask, int err)
 	}
 
 	qtask->rsp.err = err;
-	if (write(qtask->mgmt_ipc_fd, &qtask->rsp, sizeof(qtask->rsp)) < 0)
-		log_error("IPC qtask write failed: %s", strerror(errno));
+	if (write(qtask->mgmt_ipc_fd, &qtask->rsp, sizeof(qtask->rsp)) < 0) {
+		if (qtask->conn && qtask->conn->session)
+			conn_error(qtask->conn, "IPC qtask write failed: %s", strerror(errno));
+		else
+			log_error("IPC qtask write failed: %s", strerror(errno));
+	}
 	mgmt_ipc_destroy_queue_task(qtask);
 }
 


### PR DESCRIPTION
There are many logs like following which are not helpful to
locate problem when there are multiple sessions:

"unsupported opcode 0xxxx"

We can not know which connection or session the log belongs to,
so this PR find these logs and add session id, connection id
for them.

This would be helpful to locate problems according to logs.