### PR TITLE
Fix iscsi-init.service start time

### DIFF
--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -2,7 +2,16 @@
 Description=One time configuration for iscsi.service
 ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
 DefaultDependencies=no
-After=root.mount
+RequiresMountsFor=/etc/iscsi
+# systemd-remount-fs.service is optionally pulled in by
+# local-fs.target, don't start it here (no Wants=) but if
+# it's running wait for it to finish
+After=systemd-remount-fs.service
+
+[Install]
+# this ensures we are in the same transaction with
+# systemd-remount-fs.service
+WantedBy=systemd-remount-fs.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The commit e6e53d6e60bf ("Fix iscsi-init so that it runs when
root writable") added "After=root.mount" to iscsi-init.service,
but that was an error, since that means waiting for "/root".

Remove that line and add the proper configuration so that
the iscsi-init service does not try to write to
/etc/iscsi/initiatorname.iscsi unless /etc/iscsi is
writable.

Fixes: e6e53d6e60bf