### PR TITLE
REVIEW ONLY: dump of fedora modifications to etc/systemd

### DIFF
--- a/etc/systemd/iscsi-init.service
+++ b/etc/systemd/iscsi-init.service
@@ -2,9 +2,9 @@
 Description=One time configuration for iscsi.service
 ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
 DefaultDependencies=no
-After=root.mount
+Before=iscsid.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`@SBINDIR@/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'
+ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`/usr/sbin/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'

--- a/etc/systemd/iscsi-mark-root-nodes
+++ b/etc/systemd/iscsi-mark-root-nodes
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+ISCSIADM=/usr/sbin/iscsiadm
+start_iscsid=0
+start_iscsiuio=0
+
+while read t num p target flash; do
+  # strip tag number from portal, keep "ip:port"
+  portal=${p%,*}
+  transport=${t%:}
+
+  # use session number to find the iface name in use
+  num=${num#[}; num=${num%]}
+  iface=$(iscsiadm -m session -r $num | grep iface.iscsi_ifacename | cut -d= -f2)
+
+  $ISCSIADM -m node -p $portal -T $target -I $iface -o update -n node.startup -v onboot
+
+  start_iscsid=1
+
+  if [ "$transport" = bnx2i ] || [ "$transport" = qedi ]; then
+    start_iscsiuio=1
+  fi
+done < <( $ISCSIADM -m session )
+
+# force iscsid and iscsiuio to start if needed for
+# recovering sessions created in the initrd
+
+if [ "$start_iscsid" -eq 1 ]; then
+  systemctl --no-block start iscsid.service
+fi
+if [ "$start_iscsiuio" -eq 1 ]; then
+  systemctl --no-block start iscsiuio.service
+fi
+

--- a/etc/systemd/iscsi-onboot.service
+++ b/etc/systemd/iscsi-onboot.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Special handling of early boot iSCSI sessions
+Documentation=man:iscsiadm(8) man:iscsid(8)
+DefaultDependencies=no
+RefuseManualStart=true
+Before=iscsi.service
+After=systemd-remount-fs.service
+ConditionDirectoryNotEmpty=/sys/class/iscsi_session
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/libexec/iscsi-mark-root-nodes
+
+[Install]
+WantedBy=sysinit.target

--- a/etc/systemd/iscsi-shutdown.service
+++ b/etc/systemd/iscsi-shutdown.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Logout off all iSCSI sessions on shutdown
+Documentation=man:iscsid(8) man:iscsiadm(8)
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-remount-fs.service network.target iscsid.service iscsiuio.service
+Before=remote-fs-pre.target
+Wants=remote-fs-pre.target
+RefuseManualStop=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=-/usr/bin/true
+ExecStop=-/usr/sbin/iscsiadm -m node --logoutall=all

--- a/etc/systemd/iscsi.service
+++ b/etc/systemd/iscsi.service
@@ -1,18 +1,18 @@
 [Unit]
 Description=Login and scanning of iSCSI devices
 Documentation=man:iscsiadm(8) man:iscsid(8)
-Before=remote-fs.target
-After=network-online.target iscsid.service
-Requires=iscsid.socket iscsi-init.service
-Wants=network-online.target
+DefaultDependencies=no
+Before=remote-fs-pre.target
+After=network.target network-online.target iscsid.service iscsiuio.service systemd-remount-fs.service
+Wants=remote-fs-pre.target
+ConditionDirectoryNotEmpty=/var/lib/iscsi/nodes
 
 [Service]
 Type=oneshot
-ExecStart=@SBINDIR@/iscsiadm -m node --loginall=automatic -W
-ExecStop=@SBINDIR@/iscsiadm -m node --logoutall=automatic
-ExecStop=@SBINDIR@/iscsiadm -m node --logoutall=manual
-SuccessExitStatus=21 15
 RemainAfterExit=true
+ExecStart=-/usr/sbin/iscsiadm -m node --loginall=automatic
+ExecReload=-/usr/sbin/iscsiadm -m node --loginall=automatic
+SuccessExitStatus=21
 
 [Install]
 WantedBy=remote-fs.target

--- a/etc/systemd/iscsid.service
+++ b/etc/systemd/iscsid.service
@@ -4,16 +4,14 @@ Documentation=man:iscsid(8) man:iscsiuio(8) man:iscsiadm(8)
 DefaultDependencies=no
 After=network-online.target iscsiuio.service iscsi-init.service
 Before=remote-fs-pre.target
-Wants=remote-fs-pre.target
-Requires=iscsi-init.service
+Requires=iscsi-init.service iscsi-shutdown.service
 
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=@SBINDIR@/iscsid -f
+ExecStart=/usr/sbin/iscsid -f
 KillMode=mixed
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-Also=iscsid.socket

--- a/etc/systemd/iscsiuio.service
+++ b/etc/systemd/iscsiuio.service
@@ -2,17 +2,15 @@
 Description=iSCSI UserSpace I/O driver
 Documentation=man:iscsiuio(8)
 DefaultDependencies=no
-Conflicts=shutdown.target
 Requires=iscsid.service
 BindTo=iscsid.service
 After=network.target
 Before=remote-fs-pre.target iscsid.service
-Wants=remote-fs-pre.target
 
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=@SBINDIR@/iscsiuio -f
+ExecStart=/usr/sbin/iscsiuio -f
 KillMode=mixed
 Restart=on-failure
 


### PR DESCRIPTION
Various modifications and hacks have accumulated in the Fedora/RHEL iscsi unit files that I should have synced with upstream ages ago.  Some of these were uglier before but maybe could be shared now, some of these differences are just out of date with recent upstream changes.

Some of this seems overly complicated, but it's dealt with a lot of picky requests about what should be happening at boot/service restart/shutdown.

I'm just dumping the current diff in here so I can use the Github review tools to go over this stuff.