### PR TITLE
General Makefile/README cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DESTDIR ?=
 SED = /usr/bin/sed
 
 prefix = /usr
-exec_prefix = /
+exec_prefix =
 sbindir = $(exec_prefix)/sbin
 bindir = $(exec_prefix)/bin
 mandir = $(prefix)/share/man
@@ -22,17 +22,17 @@ MANPAGES = doc/iscsid.8 doc/iscsiadm.8 doc/iscsi_discovery.8 \
 		iscsiuio/docs/iscsiuio.8 doc/iscsi_fw_login.8 doc/iscsi-iname.8 \
 		doc/iscsistart.8 doc/iscsi-gen-initiatorname.8
 PROGRAMS = usr/iscsid usr/iscsiadm utils/iscsi-iname iscsiuio/src/unix/iscsiuio \
-		   usr/iscsistart
+		usr/iscsistart
 SCRIPTS = utils/iscsi_discovery utils/iscsi_fw_login utils/iscsi_offload \
-		  utils/iscsi-gen-initiatorname
+		utils/iscsi-gen-initiatorname
 INSTALL = install
-ETCFILES = etc/iscsid.conf
+CONFIGFILE = etc/iscsid.conf
 IFACEFILES = etc/iface.example
 RULESFILES = utils/50-iscsi-firmware-login.rules
 SYSTEMDFILES = etc/systemd/iscsi.service \
-			   etc/systemd/iscsi-init.service \
-			   etc/systemd/iscsid.service etc/systemd/iscsid.socket \
-			   etc/systemd/iscsiuio.service etc/systemd/iscsiuio.socket
+		etc/systemd/iscsi-init.service \
+		etc/systemd/iscsid.service etc/systemd/iscsid.socket \
+		etc/systemd/iscsiuio.service etc/systemd/iscsiuio.socket
 
 export DESTDIR prefix INSTALL
 
@@ -104,24 +104,24 @@ clean:
 	install_etc install_iface install_doc install_iname
 
 install: install_programs install_doc install_etc \
-	install_initd install_iname install_iface install_libopeniscsiusr
+	install_systemd install_iname install_iface install_libopeniscsiusr
 
 install_user: install_programs install_doc install_etc \
-	install_initd install_iname install_iface
+	install_systemd install_iname install_iface
 
 install_udev_rules:
 	$(INSTALL) -d $(DESTDIR)$(rulesdir)
-	$(INSTALL) -m 644 $(RULESFILES) $(DESTDIR)/$(rulesdir)
+	$(INSTALL) -m 644 $(RULESFILES) $(DESTDIR)$(rulesdir)
 	for f in $(RULESFILES); do \
-		p=$(DESTDIR)/$(rulesdir)/$${f##*/}; \
+		p=$(DESTDIR)$(rulesdir)/$${f##*/}; \
 		$(SED) -i -e 's:@SBINDIR@:$(sbindir):' $$p; \
 	done
 
 install_systemd:
 	$(INSTALL) -d $(DESTDIR)$(systemddir)/system
-	$(INSTALL) -m 644 $(SYSTEMDFILES) $(DESTDIR)/$(systemddir)/system
+	$(INSTALL) -m 644 $(SYSTEMDFILES) $(DESTDIR)$(systemddir)/system
 	for f in $(SYSTEMDFILES); do \
-		p=$(DESTDIR)/$(systemddir)/system/$${f##*/}; \
+		p=$(DESTDIR)$(systemddir)/system/$${f##*/}; \
 		$(SED) -i -e 's:@SBINDIR@:$(sbindir):' $$p; \
 	done
 
@@ -129,7 +129,7 @@ install_programs: $(PROGRAMS) $(SCRIPTS)
 	$(INSTALL) -d $(DESTDIR)$(sbindir)
 	$(INSTALL) -m 755 $^ $(DESTDIR)$(sbindir)
 	for f in $(SCRIPTS); do \
-		p=$(DESTDIR)/$(sbindir)/$${f##*/}; \
+		p=$(DESTDIR)$(sbindir)/$${f##*/}; \
 		$(SED) -i -e 's:@SBINDIR@:$(sbindir):' $$p; \
 	done
 
@@ -157,7 +157,7 @@ install_iface: $(IFACEFILES)
 	$(INSTALL) -d $(DESTDIR)$(etcdir)/iscsi/ifaces
 	$(INSTALL) -m 644 $^ $(DESTDIR)$(etcdir)/iscsi/ifaces
 
-install_etc: $(ETCFILES)
+install_etc: $(CONFIGFILE)
 	if [ ! -f $(DESTDIR)/etc/iscsi/iscsid.conf ]; then \
 		$(INSTALL) -d $(DESTDIR)$(etcdir)/iscsi ; \
 		$(INSTALL) -m 644 $^ $(DESTDIR)$(etcdir)/iscsi ; \

--- a/README
+++ b/README
@@ -73,7 +73,7 @@ Linux operating system with kernel version 2.6.16 or later. 2.6.14 and
 2.6.15 are partially supported. Known issues with 2.6.14 - .15 support:
 
 - If the device is using a write back cache, during session logout
-the cache sync command will fail.
+  the cache sync command will fail.
 - iscsiadm's -P 3 option will not print out scsi devices.
 - iscsid will not automatically online devices.
 
@@ -131,10 +131,13 @@ The output will be similar to the following.
 Usage: iscsid [OPTION]
 
   -c, --config=[path]     Execute in the config file (/etc/iscsi/iscsid.conf).
+  -i, --initiatorname=[path]     read initiatorname from file (/etc/iscsi/initiatorname.iscsi).
   -f, --foreground        run iscsid in the foreground
   -d, --debug debuglevel  print debugging information
   -u, --uid=uid           run as uid, default is current user
   -g, --gid=gid           run as gid, default is current user group
+  -n, --no-pid-file       do not use a pid file
+  -p, --pid=pidfile       use pid file (default /run/iscsid.pid).
   -h, --help              display this help and exit
   -v, --version           display version and exit
 
@@ -183,13 +186,13 @@ For help, run:
 
 The output will be similar to the following.
 
-iscsiadm -m discoverydb [ -hV ] [ -d debug_level ] [-P printlevel] [ -t type -p ip:port -I ifaceN ... [ -Dl ] ] | [ [ -p ip:port -t type] [ -o operation ] [ -n name ] [ -v value ] [ -lD ] ] 
-iscsiadm -m discovery [ -hV ] [ -d debug_level ] [-P printlevel] [ -t type -p ip:port -I ifaceN ... [ -l ] ] | [ [ -p ip:port ] [ -l | -D ] ] 
-iscsiadm -m node [ -hV ] [ -d debug_level ] [ -P printlevel ] [ -L all,manual,automatic ] [ -W ] [ -U all,manual,automatic ] [ -S ] [ [ -T targetname -p ip:port -I ifaceN ] [ -l | -u | -R | -s] ] [ [ -o  operation  ] [ -n name ] [ -v value ] ]
-iscsiadm -m session [ -hV ] [ -d debug_level ] [ -P  printlevel] [ -r sessionid | sysfsdir [ -R | -u | -s ] [ -o operation ] [ -n name ] [ -v value ] ]
-iscsiadm -m iface [ -hV ] [ -d debug_level ] [ -P printlevel ] [ -I ifacename | -H hostno|MAC ] [ [ -o  operation  ] [ -n name ] [ -v value ] ] [ -C ping [ -a ip ] [ -b packetsize ] [ -c count ] [ -i interval ] ]
-iscsiadm -m fw [ -d debug_level ] [ -l ]
-iscsiadm -m host [ -P printlevel ] [ -H hostno|MAC ] [ [ -C chap [ -x chap_tbl_idx ] ] | [ -C flashnode [ -A portal_type ] [ -x flashnode_idx ] ] | [ -C stats ] ] [ [ -o operation ] [ -n name ] [ -v value ] ] 
+iscsiadm -m discoverydb [-hV] [-d debug_level] [-P printlevel] [-t type -p ip:port -I ifaceN ... [-Dl]] | [[-p ip:port -t type] [-o operation] [-n name] [-v value] [-lD]]
+iscsiadm -m discovery [-hV] [-d debug_level] [-P printlevel] [-t type -p ip:port -I ifaceN ... [-l]] | [[-p ip:port] [-l | -D]] [-W]
+iscsiadm -m node [-hV] [-d debug_level] [-P printlevel] [-L all,manual,automatic,onboot] [-W] [-U all,manual,automatic,onboot] [-S] [[-T targetname -p ip:port -I ifaceN] [-l | -u | -R | -s]] [[-o  operation ] [-n name] [-v value]]
+iscsiadm -m session [-hV] [-d debug_level] [-P  printlevel] [-r sessionid | sysfsdir [-R | -u | -s] [-o operation] [-n name] [-v value]]
+iscsiadm -m iface [-hV] [-d debug_level] [-P printlevel] [-I ifacename | -H hostno|MAC] [[-o  operation ] [-n name] [-v value]] [-C ping [-a ip] [-b packetsize] [-c count] [-i interval]]
+iscsiadm -m fw [-d debug_level] [-l] [-W]
+iscsiadm -m host [-P printlevel] [-H hostno|MAC] [[-C chap [-x chap_tbl_idx]] | [-C flashnode [-A portal_type] [-x flashnode_idx]] | [-C stats]] [[-o operation] [-n name] [-v value]]
 iscsiadm -k priority
 
 
@@ -1165,7 +1168,7 @@ After that, start iSCSI as a daemon process:
 
 or alternatively, start it with debug enabled, in a seperate window,
 which will force it into "foreground" mode:
-	iscsid -d 8 
+	iscsid -d 8
 
 
 7.1.2.2 Logging into Targets

--- a/libopeniscsiusr/Makefile
+++ b/libopeniscsiusr/Makefile
@@ -11,7 +11,7 @@ endif
 DESTDIR ?=
 prefix ?= /usr
 INSTALL ?= install
-exec_prefix = /
+exec_prefix =
 sbindir = $(exec_prefix)/sbin
 
 ifndef LIB_DIR


### PR DESCRIPTION
Cleaning up the Makefiles, in preperation for adding the
ability to move files out of /etc/iscsi more easily. Also,
clean up the README file by updating it with updated
help messages, alignment, and those pesky spaces at the ends of lines.