### PR TITLE
Make etc iscsi configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,16 @@ clean:
 # note that make may still execute the blocks in parallel
 .NOTPARALLEL: install_user install_programs install_initd \
 	install_initd_redhat install_initd_debian \
-	install_etc install_iface install_doc install_iname
+	install_iface install_doc install_iname
 
-install: install_programs install_doc install_etc \
+install: install_programs install_doc \
 	install_systemd install_iname install_iface install_libopeniscsiusr \
 	install_iscsiuio
 
 install_iscsiuio:
 	$(MAKE) $(MFLAGS) -C iscsiuio install
 
-install_user: install_programs install_doc install_etc \
+install_user: install_programs install_doc \
 	install_systemd install_iname install_iface
 
 install_udev_rules:
@@ -104,7 +104,7 @@ install_programs:
 	$(MAKE) $(MFLAGS) -C utils install
 	$(MAKE) $(MFLAGS) -C usr install
 
-install_initd install_initd_redhat install_initd_debian install_ifae install_etc install_systemd install_iface:
+install_initd install_initd_redhat install_initd_debian install_ifae install_systemd install_iface:
 	$(MAKE) $(MFLAGS) -C etc $@
 
 install_doc: $(MANPAGES)
@@ -130,6 +130,6 @@ depend:
 
 .PHONY: all user install force clean install_user install_udev_rules install_systemd \
 	install_programs install_initrd install_initrd_redhat install_initrd_debian \
-	install_etc install_doc install_iname install_libopeniscsiusr
+	install_doc install_iname install_libopeniscsiusr
 
 # vim: ft=make tw=72 sw=4 ts=4:

--- a/README
+++ b/README
@@ -4,7 +4,7 @@
 
 =================================================================
 
-                                                   Sep 29, 2016
+                                                   Mar 30, 2022
 Contents
 ========
 
@@ -101,10 +101,21 @@ By default the kernel's iSCSI modules will be used. Running:
 	make install
 
 will install the iSCSI tools iscsiadm and iscsid to /sbin, by default,
-though that location can be overridden by passing in "sbindir", e.g. to
+though that location can be overridden by passing in "SBINDIR", e.g. to
 install in /usr/bin instead of /sbin:
 
-	make sbindir="/usr/sbin"
+	make SBINDIR="/usr/sbin"
+
+The default home directory for open-iscsi is /etc/iscsi. This
+directory is used for the open-iscsi database, and for the initiator
+name file initiatorname.iscsi and for the configuration file iscsid.conf.
+You can override these with two "make" parameters "HOMEDIR", for the
+initiator name and configuration files, and "DBROOT" for the open-iscsi
+databases. Both of these default to "/etc/iscsi". For example, the following
+would location the database file under /usr/lib/iscsi and leave the
+configuration and initiator name files in /etc/iscsi:
+
+	make DBROOT=/var/lib/iscsi
 
 To build and install iscsiuio, use something like:
 
@@ -126,7 +137,7 @@ iSCSI database (see next section).
 For help, run:
 	iscsid --help
 
-The output will be similar to the following.
+The output will be similar to the following (assuming a default install):
 
 Usage: iscsid [OPTION]
 
@@ -148,7 +159,8 @@ Usage: iscsid [OPTION]
 Open-iSCSI persistent configuration is stored in a number of
 directories under a configuration root directory, using a flat-file
 format. This configuration root directory is /etc/iscsi by default,
-but may also commonly be in /var/lib/iscsi.
+but may also commonly be in /var/lib/iscsi (see "DBROOT" in the Make
+options discussed earlier).
 
 Configuration is contained in directories for:
 
@@ -188,10 +200,10 @@ The output will be similar to the following.
 
 iscsiadm -m discoverydb [-hV] [-d debug_level] [-P printlevel] [-t type -p ip:port -I ifaceN ... [-Dl]] | [[-p ip:port -t type] [-o operation] [-n name] [-v value] [-lD]]
 iscsiadm -m discovery [-hV] [-d debug_level] [-P printlevel] [-t type -p ip:port -I ifaceN ... [-l]] | [[-p ip:port] [-l | -D]] [-W]
-iscsiadm -m node [-hV] [-d debug_level] [-P printlevel] [-L all,manual,automatic,onboot] [-W] [-U all,manual,automatic,onboot] [-S] [[-T targetname -p ip:port -I ifaceN] [-l | -u | -R | -s]] [[-o  operation ] [-n name] [-v value]]
-iscsiadm -m session [-hV] [-d debug_level] [-P  printlevel] [-r sessionid | sysfsdir [-R | -u | -s] [-o operation] [-n name] [-v value]]
-iscsiadm -m iface [-hV] [-d debug_level] [-P printlevel] [-I ifacename | -H hostno|MAC] [[-o  operation ] [-n name] [-v value]] [-C ping [-a ip] [-b packetsize] [-c count] [-i interval]]
-iscsiadm -m fw [-d debug_level] [-l] [-W]
+iscsiadm -m node [-hV] [-d debug_level] [-P printlevel] [-L all,manual,automatic,onboot] [-W] [-U all,manual,automatic,onboot] [-S] [[-T targetname -p ip:port -I ifaceN] [-l | -u | -R | -s]] [[-o operation ] [-n name] [-v value]]
+iscsiadm -m session [-hV] [-d debug_level] [-P printlevel] [-r sessionid | sysfsdir [-R | -u | -s] [-o operation] [-n name] [-v value]]
+iscsiadm -m iface [-hV] [-d debug_level] [-P printlevel] [-I ifacename | -H hostno|MAC] [[-o operation ] [-n name] [-v value]] [-C ping [-a ip] [-b packetsize] [-c count] [-i interval]]
+iscsiadm -m fw [-d debug_level] [-l] [-W] [[-n name] [-v value]]
 iscsiadm -m host [-P printlevel] [-H hostno|MAC] [[-C chap [-x chap_tbl_idx]] | [-C flashnode [-A portal_type] [-x flashnode_idx]] | [-C stats]] [[-o operation] [-n name] [-v value]]
 iscsiadm -k priority
 
@@ -1097,10 +1109,12 @@ Host mode with stats submode
 6. Configuration
 ================
 
-The default configuration file is /etc/iscsi/iscsid.conf. This file contains
-only configuration that could be overwritten by iSCSI Discovery,
-or manualy updated via iscsiadm utility. Its OK if this file does not
-exist, in which case compiled-in default configuration will take place
+The default configuration file is /etc/iscsi/iscsid.conf, but the
+directory is configurable with the top-level make option "homedir".
+The remainder of this document will assume the /etc/iscsi directory.
+This file contains only configuration that could be overwritten by iSCSI
+discovery, or manualy updated via iscsiadm utility. Its OK if this file
+does not exist, in which case compiled-in default configuration will take place
 for newer discovered Target nodes.
 
 See the man page and the example file for the current syntax.

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+iscsi-gen-initiatorname.8
+iscsiadm.8
+iscsid.8

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,55 @@
+# This Makefile will work only with GNU make.
+#
+# Make file for the doc sub-directory
+#
+
+ifeq ($(TOPDIR),)
+	TOPDIR = ..
+endif
+
+SED = /usr/bin/sed
+INSTALL = install
+
+DESTDIR ?=
+etcdir = /etc
+DBROOT ?= $(etcdir)/iscsi
+HOMEDIR ?= $(etcdir)/iscsi
+
+prefix ?= /usr
+mandir ?= $(prefix)/share/man
+
+MAN8DIR = $(DESTDIR)$(mandir)/man8
+
+MANPAGES_SOURCES	= iscsi_discovery.8 \
+			  iscsi_fw_login.8 \
+			  iscsi-iname.8 \
+			  iscsistart.8
+MANPAGES_SOURCES_ISCSIUIO = $(TOPDIR)/iscsiuio/docs/iscsiuio.8 
+MANPAGES_TEMPLATES	= iscsid.8.template \
+			  iscsiadm.8.template \
+			  iscsi-gen-initiatorname.8
+MANPAGES_GENERATED	= $(MANPAGES_TEMPLATES:.template=)
+MANPAGES_DEST		= $(addprefix $(MAN8DIR)/,$(MANPAGES_GENERATED)) \
+			  $(addprefix $(MAN8DIR)/,$(MANPAGES_SOURCES))
+MANPAGES_DEST_ISCSIUIO	= $(addprefix $(MAN8DIR)/,$(notdir $(MANPAGES_SOURCES_ISCSIUIO)))
+
+all: $(MANPAGES_GENERATED)
+
+install: install_doc
+
+install_doc: $(MAN8DIR) $(MANPAGES_DEST) $(MANPAGES_DEST_ISCSIUIO)
+
+$(MANPAGES_GENERATED): %.8: %.8.template
+	$(SED) -e 's:@HOMEDIR@:$(HOMEDIR):' -e 's:@DBROOT@:$(DBROOT):' $? > $@
+
+$(MANPAGES_DEST): $(MAN8DIR)/%: %
+	$(INSTALL) -m 644 $? $@
+
+$(MANPAGES_DEST_ISCSIUIO): $(MAN8DIR)/%: $(TOPDIR)/iscsiuio/docs/%
+	$(INSTALL) -m 644 $? $@
+
+$(MAN8DIR):
+	[ -d $@ ] || $(INSTALL) -d $@
+
+clean:
+	$(RM) $(MANPAGES_GENERATED)

--- a/doc/iscsi-gen-initiatorname.8.template
+++ b/doc/iscsi-gen-initiatorname.8.template
@@ -24,7 +24,7 @@ Use \fIIQN-PREFIX\fP as the prefix to the IQN generated,
 instead of the default of \fBiqn.1996-04.de.suse:01\fP.
 .SH FILES
 .TP
-/etc/iscsi/initiatorname.iscsi
+@HOMEDIR@/initiatorname.iscsi
 The file containing the initiator name. Do not edit manually.
 .SH "SEE ALSO"
 .BR iscsi-iname (8)

--- a/doc/iscsiadm.8.template
+++ b/doc/iscsiadm.8.template
@@ -1,4 +1,4 @@
-.TH ISCSIADM 8 "Mar 2021" "" "Linux Administrator's Manual"
+.TH ISCSIADM 8 "Mar 2022" "" "Linux Administrator's Manual"
 .SH NAME
 iscsiadm \- open-iscsi administration utility
 .SH SYNOPSIS
@@ -174,9 +174,25 @@ For \fIsession\fR mode, a session id (\fIsid\fR) is used. The \fIsid\fR of a ses
 found by running \fIiscsiadm \-m session \-P 1\fR. The session id and sysfs
 path are not currently persistent and is partially determined by when the
 session is setup.
+.SH NOTES
 .PP
-Note that many of the \fInode\fR and \fIdiscovery\fR operations require that the iSCSI
-daemon (iscsid) be running.
+Many of the node and discovery operations require that the iSCSI
+daemon (iscsid) be running. If running on a system that uses systemd,
+the daemon may start up automatically, if enabled, when needed.
+.PP
+Open-iscsi has two groups of files it needs to store or get access to,
+while running: the \fBHOMEDIR\fR and the \fBDBROOT\fR. The following
+describes them:
+.TP
+.B Home Directory
+The \fIhome directory\fR for open-iscsi is @HOMEDIR@. This is
+where it keeps it's configuration file (\fIiscsid.conf\fR) and it's
+initiator name file (\fIinitiatorname.iscsi\fR).
+.TP
+.B Database Root Directory
+The \fIdatabase root directory\fR for open-iscsi is @DBROOT@. This
+is where it keeps its flat database files, such as it's list of \fInode\fRs
+(see below).
 .SH OPTIONS
 .TP
 \fB\-a\fR, \fB\-\-ip=\fIipaddr\fP
@@ -232,7 +248,7 @@ This option is only valid for \fIping\fR submode.
 .TP
 \fB\-I\fR, \fB\-\-interface=\fI[iface]\fR
 The \fIinterface\fR argument specifies the iSCSI interface to use for the operation.
-iSCSI interfaces (\fIiface\fR) are defined in /etc/iscsi/ifaces. For hardware
+iSCSI interfaces (\fIiface\fR) are defined in @DBROOT@/ifaces. For hardware
 iSCSI (e.g. qla4xxx) the \fIiface\fR configuration must have the hardware address
 (\fIiface.hwaddress\fR = port's MAC address)
 and the driver/transport_name (\fIiface.transport_name\fR). The \fIiface\fR's name is
@@ -326,7 +342,7 @@ If no other options are specified: for \fIdiscovery\fR, \fIdiscoverydb\fR and
 \fInode\fR mode, all of their respective records are displayed; for \fIsession\fR mode,
 all active sessions and connections are displayed; for \fIfw\fR mode, all boot
 firmware values are displayed; for \fIhost\fR mode, all iSCSI hosts are displayed;
-and for \fIiface\fR mode, all interfaces setup in /etc/iscsi/ifaces are displayed.
+and for \fIiface\fR mode, all interfaces setup in @DBROOT@/ifaces are displayed.
 .TP
 \fB\-n\fR, \fB\-\-name=\fIname\fR
 In \fInode\fR mode, specify a field \fIname\fR in a record. In \fIflashnode\fR submode
@@ -680,17 +696,17 @@ Display all data for a given node record:
 \fBsh#\fR iscsiadm \-\-mode node \-\-targetname iqn.2001-05.com.doe:test \-\-portal 192.168.1.1:3260
 .SH FILES
 .TP
-/etc/iscsi/iscsid.conf
+@HOMEDIR@/iscsid.conf
 The configuration file read by \fBiscsid\fR and \fBiscsiadm\fR on startup.
 .TP
-/etc/iscsi/initiatorname.iscsi
+@HOMEDIR@/initiatorname.iscsi
 The file containing the iSCSI InitiatorName and InitiatorAlias read by
 \fBiscsid\fR and \fBiscsiadm\fR on startup.
 .TP
-/etc/iscsi/nodes/
+@DBROOT@/nodes/
 This directory contains the nodes with their targets.
 .TP
-/etc/iscsi/send_targets
+@DBROOT@/send_targets
 This directory contains the portals.
 .SH "SEE ALSO"
 .BR iscsid (8)

--- a/doc/iscsid.8.template
+++ b/doc/iscsid.8.template
@@ -15,11 +15,11 @@ iSCSI database.
 .TP
 .BI [-c|--config=]\fIconfig\-file\fP
 Read configuration from \fIconfig\-file\fR rather than the default
-\fI/etc/iscsi/iscsid.conf\fR file.
+\fI@HOMEDIR@/iscsid.conf\fR file.
 .TP
 .BI [-i|--initiatorname=]\fIiname\-file\fP
 Read initiator name from \fIiname\-file\fR rather than the default
-\fI/etc/iscsi/initiatorname.iscsi\fR file.
+\fI@HOMEDIR@/initiatorname.iscsi\fR file.
 .TP
 .BI [-f|--foreground]
 run
@@ -55,14 +55,14 @@ display version and exit.
 
 .SH FILES
 .TP
-/etc/iscsi/iscsid.conf
+@HOMEDIR@/iscsid.conf
 The configuration file read by
 .B iscsid
 and
 .B iscsiadm
 on startup.
 .TP
-/etc/iscsi/initiatorname.iscsi
+@HOMEDIR@/initiatorname.iscsi
 The file containing the iSCSI initiatorname
 and initiatoralias read by
 .B iscsid
@@ -70,7 +70,7 @@ and
 .B iscsiadm
 on startup.
 .TP
-/etc/iscsi/nodes
+@DBROOT@/nodes
 Open-iSCSI persistent configuration database
 
 .SH "SEE ALSO"

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -3,13 +3,19 @@
 # 	initd and systemd subdirectories
 #
 
+ifeq ($(TOPDIR),)
+	TOPDIR = ..
+endif
+
 prefix = /usr
 DESTDIR ?=
-SBINDIR ?= $(DESTDIR)/sbin
+SBINDIR ?= /sbin
+
+ISCSI_INAME ?= $(TOPDIR)/utils/iscsi-iname
 
 systemddir ?= $(DESTDIR)$(prefix)/lib/systemd
-etcdir = $(DESTDIR)/etc
-initddir ?= $(etcdir)/init.d
+etcdir = /etc
+initddir ?= $(DESTDIR)$(etcdir)/init.d
 
 HOMEDIR ?= $(etcdir)/iscsi
 
@@ -24,12 +30,14 @@ SYSTEMD_TEMPLATE_FILES	= iscsi-init.service.template \
 			  iscsiuio.service.template
 SYSTEMD_TEMPLATES	= $(addprefix systemd/,$(SYSTEMD_TEMPLATE_FILES))
 SYSTEMD_GENERATED_SERVICE_FILES	= $(SYSTEMD_TEMPLATES:.template=)
-SYSTEMD_DEST_FILES	= $(addprefix $(systemddir)/system/,$(notdir $(SYSTEMD_SOURCES))) \
+SYSTEMD_DEST_FILES	= $(addprefix $(systemddir)/system/,$(SYSTEMD_SOURCE_FILES)) \
 			  $(addprefix $(systemddir)/system/,$(notdir $(SYSTEMD_GENERATED_SERVICE_FILES)))
 IFACE_FILES		= iface.example
-IFACE_DEST_FILES	= $(addprefix $(HOMEDIR)/ifaces/,$(IFACE_FILES))
+IFACE_DEST_FILES	= $(addprefix $(DESTDIR)$(DBROOT)/ifaces/,$(IFACE_FILES))
 ETC_FILES		= iscsid.conf
-ETC_DEST_FILES		= $(addprefix $(HOMEDIR)/,$(ETC_FILES))
+ETC_DEST_FILES		= $(addprefix $(DESTDIR)$(HOMEDIR)/,$(ETC_FILES))
+
+INAME_DEST_FILE		= $(DESTDIR)$(HOMEDIR)/initiatorname.iscsi
 
 all: $(SYSTEMD_SOURCES) $(SYSTEMD_GENERATED_SERVICE_FILES)
 
@@ -38,14 +46,14 @@ $(SYSTEMD_GENERATED_SERVICE_FILES): systemd/%.service: systemd/%.service.templat
 
 install: install_systemd install_iface install_etc
 
-install_iface: $(IFACE_DEST_FILES)
+install_iface: $(DESTDIR)$(DBROOT)/ifaces $(IFACE_DEST_FILES)
 
-$(IFACE_DEST_FILES): $(HOMEDIR)/ifaces/%: %
+$(IFACE_DEST_FILES): $(DESTDIR)$(DBROOT)/ifaces/%: %
 	$(INSTALL) -m 644 $? $@
 
-install_etc: $(ETC_DEST_FILES)
+install_etc: $(DESTDIR)$(HOMEDIR) $(ETC_DEST_FILES)
 
-$(ETC_DEST_FILES): $(HOMEDIR)/%: %
+$(ETC_DEST_FILES): $(DESTDIR)$(HOMEDIR)/%: %
 	$(INSTALL) -m 644 $? $@
 
 install_initd_distro = $(INSTALL) -m 755 $(1) $(initddir)/open-iscsi/
@@ -57,9 +65,6 @@ install_initd: $(initddir)/open-iscsi
 		$(call install_initd_distro,initd/initd.debian) ; \
 	fi
 
-$(initddir)/open-iscsi:
-	[ -d $@ ] || $(INSTALL) -d $@
-
 install_initd_redhat: $(initddir)/open-iscsi
 	$(call install_initd_distro,initd/initd.redhat)
 
@@ -68,11 +73,25 @@ install_initd_debian: $(initddir)/open-iscsi
 
 install_systemd: $(systemddir)/system $(SYSTEMD_DEST_FILES)
 
-$(systemddir)/system:
-	[ -d $@ ] || $(INSTALL) -d -m 775 $@
-
 $(SYSTEMD_DEST_FILES): $(systemddir)/system/%: systemd/%
 	$(INSTALL) $? $@
+
+install_iname: $(DESTDIR)$(HOMEDIR) $(ISCSI_INAME)
+	if [ ! -f $(INAME_DEST_FILE) ]; then \
+		INAME="`$(ISCSI_INAME)`" ; \
+		echo "InitiatorName=$$INAME" > $(INAME_DEST_FILE) ; \
+		echo "***************************************************" ; \
+		echo "Setting InitiatorName to $$INAME" ; \
+		echo "To override edit $(INAME_DEST_FILE)" ; \
+		echo "***************************************************" ; \
+	fi
+
+$(ISCSI_INAME):
+	$(MAKE) $(MFLAGS) -c $(TOPDIR)/utils $(notdir $@)
+
+# make needed directories
+$(systemddir)/system $(DESTDIR)$(HOMEDIR) $(DESTDIR)$(DBROOT)/ifaces $(initddir)/open-iscsi:
+	[ -d $@ ] || $(INSTALL) -d -m 775 $@
 
 clean:
 	$(RM) $(SYSTEMD_GENERATED_SERVICE_FILES)

--- a/include/iscsi_net_util.h
+++ b/include/iscsi_net_util.h
@@ -2,7 +2,12 @@
 #define __ISCSI_NET_UTIL_h__
 
 #define ISCSI_HWADDRESS_BUF_SIZE 18
-#define ISCSIUIO_PATH "/sbin/iscsiuio"
+
+#ifndef SBINDIR
+#define SBINDIR	"/sbin"
+#endif
+
+#define ISCSIUIO_PATH SBINDIR"/iscsiuio"
 
 extern int net_get_transport_name_from_netdev(char *netdev, char *transport);
 extern int net_get_netdev_from_hwaddress(char *hwaddress, char *netdev);

--- a/iscsiuio/.gitignore
+++ b/iscsiuio/.gitignore
@@ -23,3 +23,5 @@ libtool
 ltmain.sh
 missing
 
+# generated man page
+iscsiuio.8.gz

--- a/libopeniscsiusr/Makefile
+++ b/libopeniscsiusr/Makefile
@@ -12,7 +12,9 @@ DESTDIR ?=
 prefix ?= /usr
 INSTALL ?= install
 exec_prefix =
-sbindir = $(exec_prefix)/sbin
+etcdir = $(DESTDIR)/etc
+SBINDIR ?= $(exec_prefix)/sbin
+DBROOT ?= $(etcdir)/iscsi
 
 ifndef LIB_DIR
 	ifeq ($(shell test -d /lib64 && echo 1),1)
@@ -50,7 +52,8 @@ OBJS = context.o misc.o session.o sysfs.o iface.o idbm.o node.o default.o
 CFLAGS ?= -O2 -g
 CFLAGS += -Wall -Werror -Wextra -fvisibility=hidden -fPIC
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)
-CFLAGS += -DSBINDIR=\"$(sbindir)\"
+CFLAGS += -DSBINDIR=\"$(SBINDIR)\"
+CFLAGS += -DISCSI_DB_ROOT=\"$(DBROOT)\"
 
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
 

--- a/libopeniscsiusr/idbm.h
+++ b/libopeniscsiusr/idbm.h
@@ -30,8 +30,12 @@
 
 #include "libopeniscsiusr/libopeniscsiusr_common.h"
 
-#define ISCSI_CONFIG_ROOT	"/etc/iscsi/"
-#define IFACE_CONFIG_DIR	ISCSI_CONFIG_ROOT"ifaces"
+#ifndef ISCSI_DB_ROOT
+#define ISCSI_DB_ROOT "/etc/iscsi"
+#endif
+
+#define	IFACE_CONFIG_DIR	ISCSI_DB_ROOT"/ifaces"
+
 #define AUTH_STR_MAX_LEN	256
 #define BOOT_NAME_MAXLEN	256
 #define IDBM_DUMP_SIZE		8192

--- a/libopeniscsiusr/node.h
+++ b/libopeniscsiusr/node.h
@@ -44,7 +44,7 @@ struct iscsi_node {
 	char					portal[NI_MAXHOST * 2];
 };
 
-#define NODE_CONFIG_DIR		ISCSI_CONFIG_ROOT"nodes"
+#define NODE_CONFIG_DIR		ISCSI_DB_ROOT"/nodes"
 
 /* Might be public in the future */
 __DLL_LOCAL void iscsi_node_free(struct iscsi_node *node);

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -7,7 +7,8 @@ endif
 INSTALL = install
 
 DESTDR ?=
-SBINDIR ?= $(DESTDIR)/sbin
+SBINDIR ?= /sbin
+etcdir = /etc
 
 OSNAME=$(shell uname -s)
 
@@ -37,6 +38,9 @@ IPC_OBJ=ioctl.o
 endif
 endif
 
+DBROOT ?= $(etcdir)/iscsi
+HOMEDIR ?= $(etcdir)/iscsi
+
 PKG_CONFIG = /usr/bin/pkg-config
 
 CFLAGS ?= -O2 -g
@@ -51,9 +55,11 @@ LDFLAGS += $(shell $(PKG_CONFIG) --libs libsystemd)
 else
 CFLAGS += -DNO_SYSTEMD
 endif
+CFLAGS += -DISCSI_DB_ROOT=\"$(DBROOT)\"
+CFLAGS += -DISCSI_CONFIG_ROOT=\"$(HOMEDIR)\"
 
 PROGRAMS	= iscsid iscsiadm iscsistart
-PROGRAMS_DEST	= $(addprefix $(SBINDIR)/,$(PROGRAMS))
+PROGRAMS_DEST	= $(addprefix $(DESTDIR)$(SBINDIR)/,$(PROGRAMS))
 
 # libc compat files
 SYSDEPS_SRCS = $(sort $(wildcard ../utils/sysdeps/*.o))
@@ -85,12 +91,12 @@ iscsistart: $(ISCSI_LIB_SRCS) $(INITIATOR_SRCS) $(FW_BOOT_SRCS) \
 		iscsistart.o statics.o
 	$(CC) $(CFLAGS) $^ -o $@ -lcrypto -lrt $(LDFLAGS) $(ISCSI_LIB)
 
-install: $(SBINDIR) $(PROGRAMS_DEST)
+install: $(DESTDIR)$(SBINDIR) $(PROGRAMS_DEST)
 
-$(SBINDIR):
+$(DESTDIR)$(SBINDIR):
 	[ -d $@ ] || $(INSTALL) -d $@
 
-$(PROGRAMS_DEST): $(SBINDIR)/%: %
+$(PROGRAMS_DEST): $(DESTDIR)$(SBINDIR)/%: %
 	$(INSTALL) -m 755 $? $@
 
 clean:

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -1835,7 +1835,7 @@ int idbm_print_all_discovery(int info_level)
  * @port: rec's port
  *
  * This will run fn over all recs with the {targetname,tpgt,ip,port}
- * id. It does not iterate over the ifaces setup in /etc/iscsi/ifaces.
+ * id. It does not iterate over the ifaces setup in the iface DB directory.
  *
  * fn should return -1 if it skipped the rec, an ISCSI_ERR error code if
  * the operation failed or 0 if fn was run successfully.
@@ -3031,9 +3031,9 @@ free_info:
 int idbm_init(idbm_get_config_file_fn *fn)
 {
 	/* make sure root db dir is there */
-	if (access(ISCSI_CONFIG_ROOT, F_OK) != 0) {
-		if (mkdir(ISCSI_CONFIG_ROOT, 0770) != 0) {
-			log_error("Could not make %s %d", ISCSI_CONFIG_ROOT,
+	if (access(ISCSI_DB_ROOT, F_OK) != 0) {
+		if (mkdir(ISCSI_DB_ROOT, 0770) != 0) {
+			log_error("Could not make %s %d", ISCSI_DB_ROOT,
 				   errno);
 			return errno;
 		}

--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -30,12 +30,13 @@
 #include "list.h"
 #include "flashnode.h"
 
-#define NODE_CONFIG_DIR		ISCSI_CONFIG_ROOT"nodes"
-#define SLP_CONFIG_DIR		ISCSI_CONFIG_ROOT"slp"
-#define ISNS_CONFIG_DIR		ISCSI_CONFIG_ROOT"isns"
-#define STATIC_CONFIG_DIR	ISCSI_CONFIG_ROOT"static"
-#define FW_CONFIG_DIR		ISCSI_CONFIG_ROOT"fw"
-#define ST_CONFIG_DIR		ISCSI_CONFIG_ROOT"send_targets"
+#define NODE_CONFIG_DIR		ISCSI_DB_ROOT"/nodes"
+#define SLP_CONFIG_DIR		ISCSI_DB_ROOT"/slp"
+#define ISNS_CONFIG_DIR		ISCSI_DB_ROOT"/isns"
+#define STATIC_CONFIG_DIR	ISCSI_DB_ROOT"/static"
+#define FW_CONFIG_DIR		ISCSI_DB_ROOT"/fw"
+#define ST_CONFIG_DIR		ISCSI_DB_ROOT"/send_targets"
+
 #define ST_CONFIG_NAME		"st_config"
 #define ISNS_CONFIG_NAME	"isns_config"
 

--- a/usr/iface.c
+++ b/usr/iface.c
@@ -93,8 +93,8 @@ static void iface_init(struct iface_rec *iface)
 }
 
 /*
- * default is to use tcp through whatever the network layer
- * selects for us with the /etc/iscsi/initiatorname.iscsi iname.
+ * Default is to use tcp through whatever the network layer
+ * selects for us with the initiatorname.iscsi iname.
  */
 void iface_setup_defaults(struct iface_rec *iface)
 {

--- a/usr/iface.h
+++ b/usr/iface.h
@@ -22,7 +22,7 @@
 
 #include <libopeniscsiusr/libopeniscsiusr.h>
 
-#define IFACE_CONFIG_DIR	ISCSI_CONFIG_ROOT"ifaces"
+#define IFACE_CONFIG_DIR	ISCSI_DB_ROOT"/ifaces"
 
 struct iface_rec;
 struct list_head;

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -34,15 +34,19 @@
 #include "list.h"
 #include "log.h"
 
+#ifndef ISCSI_CONFIG_ROOT
 #define ISCSI_CONFIG_ROOT	"/etc/iscsi/"
+#endif
 
-#define CONFIG_FILE		ISCSI_CONFIG_ROOT"iscsid.conf"
-#define INITIATOR_NAME_FILE	ISCSI_CONFIG_ROOT"initiatorname.iscsi"
+#define CONFIG_FILE		ISCSI_CONFIG_ROOT"/iscsid.conf"
+#define INITIATOR_NAME_FILE	ISCSI_CONFIG_ROOT"/initiatorname.iscsi"
 
 #define PID_FILE		"/run/iscsid.pid"
+
 #ifndef LOCK_DIR
 #define LOCK_DIR		"/run/lock/iscsi"
 #endif
+
 #define LOCK_FILE		LOCK_DIR"/lock"
 #define LOCK_WRITE_FILE		LOCK_DIR"/lock.write"
 

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -95,16 +95,16 @@ static void usage(int status)
 		printf("Usage: %s [OPTION]\n", program_name);
 		printf("\
 Open-iSCSI initiator daemon.\n\
-  -c, --config=[path]     Execute in the config file (" CONFIG_FILE ").\n\
+  -c, --config=[path]     Execute using the config file (" CONFIG_FILE ").\n\
   -i, --initiatorname=[path]     read initiatorname from file (" INITIATOR_NAME_FILE ").\n\
-  -f, --foreground        make the program run in the foreground\n\
-  -d, --debug debuglevel  print debugging information\n\
-  -u, --uid=uid           run as uid, default is current user\n\
-  -g, --gid=gid           run as gid, default is current user group\n\
-  -n, --no-pid-file       do not use a pid file\n\
-  -p, --pid=pidfile       use pid file (default " PID_FILE ").\n\
-  -h, --help              display this help and exit\n\
-  -v, --version           display version and exit\n\
+  -f, --foreground        Make the program run in the foreground\n\
+  -d, --debug debuglevel  Print debugging information\n\
+  -u, --uid=uid           Run as uid, default is current user\n\
+  -g, --gid=gid           Run as gid, default is current user group\n\
+  -n, --no-pid-file       Do not use a pid file\n\
+  -p, --pid=pidfile       Use pid file (default " PID_FILE ").\n\
+  -h, --help              Display this help and exit\n\
+  -v, --version           Display version and exit\n\
 ");
 	}
 	exit(status);

--- a/usr/iscsid_req.c
+++ b/usr/iscsid_req.c
@@ -46,7 +46,7 @@ static void iscsid_startup(void)
 	if (!startup_cmd) {
 		log_error("iscsid is not running. Could not start it up "
 			  "automatically using the startup command in the "
-			  "/etc/iscsi/iscsid.conf iscsid.startup setting. "
+			  "iscsid.conf iscsid.startup setting. "
 			  "Please check that the file exists or that your "
 			  "init scripts have started iscsid.");
 		return;

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -12,33 +12,35 @@ INSTALL = install
 CHMOD = chmod
 
 DESTDIR ?=
-SBINDIR ?= $(DESTDIR)/sbin
+SBINDIR ?= /sbin
+etcdir = /etc
+HOMEDIR ?= $(etcdir)/iscsi
 
-ETCDIR = $(DESTDIR)/etc
+ETCDIR = /etc
 RULESDIR = $(ETCDIR)/udev/rules.d
 
 CFLAGS ?= -O2 -fno-inline -g
 CFLAGS += -Wall -Wextra -Wstrict-prototypes
 
 PROGRAMS	= iscsi-iname
-PROGRAMS_DEST	= $(addprefix $(SBINDIR)/,$(PROGRAMS))
+PROGRAMS_DEST	= $(addprefix $(DESTDIR)$(SBINDIR)/,$(PROGRAMS))
 
 SCRIPTS_SOURCES		= iscsi_discovery.sh iscsi_offload.sh
 SCRIPTS_TEMPLATES	= iscsi_fw_login.sh.template iscsi-gen-initiatorname.sh.template
 SCRIPTS_GENERATED	= $(SCRIPTS_TEMPLATES:.template=)
-SCRIPTS_DEST		= $(addprefix $(SBINDIR)/,$(basename $(SCRIPTS_GENERATED))) \
-			  $(addprefix $(SBINDIR)/,$(basename $(SCRIPTS_SOURCES)))
+SCRIPTS_DEST		= $(addprefix $(DESTDIR)$(SBINDIR)/,$(basename $(SCRIPTS_GENERATED))) \
+			  $(addprefix $(DESTDIR)$(SBINDIR)/,$(basename $(SCRIPTS_SOURCES)))
 
 RULESFILES_TEMPLATES	= 50-iscsi-firmware-login.rules.template
 RULESFILES_GENERATED	= $(RULESFILES_TEMPLATES:.template=)
-RULESFILES_DEST		= $(addprefix $(RULESDIR)/,$(RULESFILES_GENERATED))
+RULESFILES_DEST		= $(addprefix $(DESTDIR)$(RULESDIR)/,$(RULESFILES_GENERATED))
 
 OBJS = iscsi-iname.o md5.o
 
 all: $(PROGRAMS) $(SCRIPTS_GENERATED) $(RULESFILES_GENERATED)
 
 $(SCRIPTS_GENERATED): %.sh: %.sh.template
-	$(SED) -e 's:@SBINDIR@:$(SBINDIR):' $? > $@
+	$(SED) -e 's:@SBINDIR@:$(SBINDIR):' -e 's:@HOMEDIR@:$(HOMEDIR):' $? > $@
 	$(CHMOD) 755 $@
 
 $(RULESFILES_GENERATED): %.rules: %.rules.template
@@ -47,20 +49,21 @@ $(RULESFILES_GENERATED): %.rules: %.rules.template
 iscsi-iname: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(DBM_LIB) -o $@
 
-install: $(SBINDIR) $(RULESDIR) $(PROGRAMS_DEST) $(SCRIPTS_DEST) $(RULESFILES_DEST)
+install: $(DESTDIR)$(SBINDIR) $(DESTDIR)$(RULESDIR) \
+	$(PROGRAMS_DEST) $(SCRIPTS_DEST) $(RULESFILES_DEST)
 
-$(PROGRAMS_DEST): $(SBINDIR)/%: %
+$(PROGRAMS_DEST): $(DESTDIR)$(SBINDIR)/%: %
 	$(INSTALL) -m 755 $? $@
 
-$(SCRIPTS_DEST): $(SBINDIR)/%: %.sh
+$(SCRIPTS_DEST): $(DESTDIR)$(SBINDIR)/%: %.sh
 	$(INSTALL) -m 755 $? $@
 
 install_udev_rules: $(RULESFILES_DEST)
 
-$(RULESFILES_DEST): $(RULESDIR)/%: %
+$(RULESFILES_DEST): $(DESTDIR)$(RULESDIR)/%: %
 	$(INSTALL) -m 644 $? $@
 
-$(SBINDIR) $(RULESDIR):
+$(DESTDIR)$(SBINDIR) $(DESTDIR)$(RULESDIR):
 	[ -d $@ ] || $(INSTALL) -d $@
 
 clean:

--- a/utils/fwparam_ibft/Makefile
+++ b/utils/fwparam_ibft/Makefile
@@ -24,6 +24,7 @@ ifeq ($(TOPDIR),)
 	TOPDIR = ../..
 endif
 
+SBINDIR ?= $(DESTDIR)/sbin
 
 SYSDEPS_OBJS = $(sort $(wildcard ../sysdeps/*.o))
 OBJS := fw_entry.o fwparam_sysfs.o $(SYSDEPS_OBJS) \
@@ -35,6 +36,7 @@ CFLAGS ?= -O2 -g
 WARNFLAGS ?= -Wall -Wstrict-prototypes -Wno-format-truncation
 CFLAGS += -fPIC $(WARNFLAGS) -I$(TOPDIR)/include -I$(TOPDIR)/usr -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
+CFLAGS += -DSBINDIR=\"$(SBINDIR)\"
 
 LDFLAGS += -L$(TOPDIR)/libopeniscsiusr -liscsiusr
 

--- a/utils/iscsi-gen-initiatorname.sh.template
+++ b/utils/iscsi-gen-initiatorname.sh.template
@@ -9,7 +9,7 @@
 #
 
 NAME="$0"
-INAME_FILE="/etc/iscsi/initiatorname.iscsi"
+INAME_FILE="@HOMEDIR@/initiatorname.iscsi"
 IQN_PREFIX="iqn.1996-04.de.suse:01"
 
 IBFT_COMMENTS="\


### PR DESCRIPTION
This large commit adds "DBROOT=/some/dir" and "HOMEDIR=/some/other/dir" options to the Makefiles, so that files can be moved out of /etc/iscsi if desired. DBROOT is for the database files, which some distributions have already moved to /var/lib/iscsi -- so this might make that easier. HOMEDIR is where iscsid.conf and initiatorname.iscsi live. Both still default to /etc/iscsi, for now, though my hope is that the database files will moved to /var/lib/iscsi, by default, soon.