### PR TITLE
Make fwparam_ibft build more reliable.

### DIFF
--- a/usr/fwparam_ibft/Makefile
+++ b/usr/fwparam_ibft/Makefile
@@ -24,6 +24,8 @@ ifeq ($(TOPDIR),)
 	TOPDIR = ../..
 endif
 
+BISON = bison
+
 SBINDIR ?= $(DESTDIR)/sbin
 
 SYSDEPS_OBJS = $(sort $(wildcard ../sysdeps/*.o))
@@ -45,6 +47,22 @@ clean:
 	$(RM) $(CLEANFILES) .depend
 
 $(OBJS): prom_parse.tab.h prom_parse.h
+
+#
+# This directory is set up so that lex and bison should not have
+# to be run to generate C files, since the C files have already
+# been checked in and are present. This eliminates the need to run
+# them on systems where those tools may not be present. If you wish
+# to run either of them to regenerate their output files, remove
+# the output files first. This prevents these tools from being run
+# again if the output files are already present.
+#
+
+prom_lex.c: prom_lex.l
+	@[ -f $@ ] || $(LEX) -t $? > $@
+
+prom_parse.tab.c prom_parse.tab.h: prom_parse.y
+	@[ -f prom_parse.tab.c ] && [ -f prom_parse.tab.h ] || $(BISON) -H $?
 
 depend:
 	$(CC) $(CFLAGS) -M `ls *.c` > .depend

--- a/usr/fwparam_ibft/README
+++ b/usr/fwparam_ibft/README
@@ -13,7 +13,11 @@ tools, but the system of having static
 parsing and lexical analysis has worked for
 so long (and isn't broken), it would be a
 shame to change and break it. So the static
-files remain, for now.
+files remain, for now. If you actually wish
+to rerun either of these tools, the Makefile
+is set up so that you have to first remove the
+generated files (prom_lex.c for lex, prom_parse.tab.c,
+and prom_parse.tab.h for bison).
 
 Note: if you wish to use these object files,
 they have two external requirements: they


### PR DESCRIPTION
This build has lex and bison source files, but
they are not normally used to regenerate C files,
since that has been done ahead of time, statically,
to handle the case when users building the software
may not have these tools. But some build systems
think the generated C files need to be regenerated
because the timestamp on the source and generated
files is so close, just because of the order the
files were populated in this directory. So we tell
the Makefile to only generate C files if those
files are missing. This should have no effect,
since these files should never need to be
regenerated unless we change lex or bison logic.