### PR TITLE
iscsiuio: fix LDADD

### DIFF
--- a/iscsiuio/src/unix/Makefile.am
+++ b/iscsiuio/src/unix/Makefile.am
@@ -27,16 +27,13 @@ iscsiuio_CFLAGS = 	$(AM_CFLAGS)		\
 			$(LIBNL_CFLAGS)		\
 			-DBYTE_ORDER=@ENDIAN@
 
-iscsiuio_LIBS = 	$(AM_LIBS)		\
-			-ldl			\
-			-rdynamic		\
-			$(LIBNL_LIBS)		\
-			-lpthread
-
-iscsiuio_LDADD  = 	$(AM_LDADD) \
-			${top_srcdir}/src/uip/lib_iscsi_uip.a	\
-			${top_srcdir}/src/apps/dhcpc/lib_apps_dhcpc.a\
+iscsiuio_LDADD = 	${top_srcdir}/src/uip/lib_iscsi_uip.a   		\
+			${top_srcdir}/src/apps/dhcpc/lib_apps_dhcpc.a   	\
 			${top_srcdir}/src/apps/brcm-iscsi/lib_apps_brcm_iscsi.a \
-			${top_srcdir}/src/unix/libs/lib_iscsiuio_hw_cnic.a
+			${top_srcdir}/src/unix/libs/lib_iscsiuio_hw_cnic.a	\
+			$(AM_LDADD)						\
+			-ldl							\
+			$(LIBNL_LIBS)						\
+			-lpthread
 
 iscsiuio_YFLAGS = -d


### PR DESCRIPTION
iscsiuio: fix LDADD

- We don't want to use _LIBS here, we're building a library, not an executable.
- We want LDADD for the whole lot (not a mix of LDFLAGS/LIBS/LDADD),
but put the objects/libraries (.a files) first so that -l* works correctly.

Closes: https://github.com/open-iscsi/open-iscsi/issues/337
Fixes: 9fbd6009cd917f1152a367fa7e5ae3993133c1e4
Signed-off-by: Sam James <sam@gentoo.org>