### PR TITLE
Add ability to specify name-value parameters when creating a new iface

### DIFF
--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -2614,6 +2614,7 @@ static int exec_iface_op(struct iscsi_context *ctx,
 		rc = iface_conf_write(iface);
 		if (rc)
 			goto new_fail;
+		iface_param_update(iface, params);
 		printf("New interface %s added\n", iface->name);
 		break;
 new_fail:


### PR DESCRIPTION
Add ability to specify name-value parameters when creating a new iface
like following:

root# iscsiadm -m iface -I test -o new -n iface.initiatorname -v iqn.2016-04.com.open-iscsi:17a3c9bc2d
test updated.
New interface test added
root# iscsiadm -m iface -I test | grep initiatorname
iface.initiatorname = iqn.2016-04.com.open-iscsi:17a3c9bc2d

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>