### PR TITLE
Fix ibft-rule-generator shell error

### DIFF
--- a/etc/systemd/ibft-rule-generator
+++ b/etc/systemd/ibft-rule-generator
@@ -18,7 +18,7 @@
 # so we need to hook in before that.
 #
 IBFT_RULE_DIR=/run/udev/rules.d
-IBFT_RULES=$(IBFT_RULE_DIR)/79-ibft.rules
+IBFT_RULES=${IBFT_RULE_DIR}/79-ibft.rules
 
 # ensure we have a rules directory and no rules file
 if [ -d ${IBFT_RULE_DIR} ] ; then


### PR DESCRIPTION
Commit fe2c59e06a42 ("Create an systemd iBFT rule generator")
created ibft-rule-generator, but it contains a syntax error,
causing this error message when its run:

> /usr/lib/systemd/system-generators/ibft-rule-generator: line 21: IBFT_RULE_DIR: command not found

This fixes that error.