### PR TITLE
Add a 'distclean' Makefile top-level target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,14 @@ iscsiuio/configure: iscsiuio/configure.ac iscsiuio/Makefile.am
 
 force: ;
 
-clean:
-	$(MAKE) $(MFLAGS) -C utils/sysdeps clean
-	$(MAKE) $(MFLAGS) -C utils clean
-	$(MAKE) $(MFLAGS) -C usr clean
-	$(MAKE) $(MFLAGS) -C etc clean
-	$(MAKE) $(MFLAGS) -C libopeniscsiusr clean
-	[ ! -f iscsiuio/Makefile ] || $(MAKE) $(MFLAGS) -C iscsiuio clean
-	[ ! -f iscsiuio/Makefile ] || $(MAKE) $(MFLAGS) -C iscsiuio distclean
+clean distclean:
+	$(MAKE) $(MFLAGS) -C utils/sysdeps $@
+	$(MAKE) $(MFLAGS) -C utils $@
+	$(MAKE) $(MFLAGS) -C usr $@
+	$(MAKE) $(MFLAGS) -C etc $@
+	$(MAKE) $(MFLAGS) -C libopeniscsiusr $@
+	$(MAKE) $(MFLAGS) -C doc $@
+	[ ! -f iscsiuio/Makefile ] || $(MAKE) $(MFLAGS) -C iscsiuio $@
 
 # this is for safety
 # now -jXXX will still be safe
@@ -127,4 +127,6 @@ depend:
 
 .PHONY: all user install force clean install_user install_udev_rules install_systemd \
 	install_programs install_initrd install_initrd_redhat install_initrd_debian \
-	install_doc install_iname install_libopeniscsiusr install_etc install_ec_all
+	install_doc install_iname install_libopeniscsiusr install_etc install_etc_all \
+	distclean depend install_initd install_initd_redhat install_initd_debian \
+	install_iscsiuio

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,5 +47,9 @@ $(MANPAGES_DEST): $(MAN8DIR)/%: %
 $(MAN8DIR):
 	[ -d $@ ] || $(INSTALL) -d $@
 
-clean:
+clean: ;
+
+distclean:
 	$(RM) $(MANPAGES_GENERATED)
+
+.PHONY: all install install_doc clean distclean

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -104,8 +104,12 @@ $(DESTDIR)$(systemddir)/system $(DESTDIR)$(systemddir)/system-generators $(DESTD
 		$(DESTDIR)$(DBROOT)/ifaces $(DESTDIR)$(initddir)/open-iscsi:
 	[ -d $@ ] || $(INSTALL) -d -m 775 $@
 
-clean:
+clean: ;
+
+distclean:
 	$(RM) $(SYSTEMD_GENERATED_SERVICE_FILES)
 
 .PHONY: all clean install install_iface install_initd install_initd_redhat \
-	install_initd_debian install_systemd
+	install_initd_debian install_systemd distclean install_iname \
+	install_systemd_generator_files install_systemd_service_files \
+	install_initd_distro install_etc

--- a/libopeniscsiusr/Makefile
+++ b/libopeniscsiusr/Makefile
@@ -73,6 +73,8 @@ clean:
 	$(RM) vgcore* core *.a *.o *.gz *.so *.so.* $(TESTS)
 	$(RM) -r docs/man
 
+distclean: ;
+
 $(TESTS): $(LIBS)
 $(TESTS): CFLAGS += -I$(TOPDIR)/libopeniscsiusr -g
 $(TESTS): LDFLAGS += $(LIBADD) -L$(TOPDIR)/libopeniscsiusr -lopeniscsiusr
@@ -121,3 +123,6 @@ docs/man/$(EXTRA_MAN_FILES).gz: $(HEADERS)
 		gzip -f $$file; \
 	done
 	find docs/man -type f -name \*[0-9].gz
+
+.PHONY: all install clean distclean doc install_pkg_files install_docs \
+	install_libs check

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -120,6 +120,10 @@ clean:
 		$(PROGRAMS) .depend
 	$(MAKE) $(MFLAGS) -C $(FW_BOOT_DIR) clean
 
+distclean: ;
+
+.PHONY: all install clean distclean depend
+
 depend:
 	$(CC) $(CFLAGS) -M `ls *.c` > .depend
 	$(MAKE) $(MFLAGS) -C $(FW_BOOT_DIR) depend

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -68,9 +68,13 @@ $(DESTDIR)$(SBINDIR) $(DESTDIR)$(RULESDIR):
 clean:
 	$(RM) $(OBJS)
 	$(RM) $(PROGRAMS)
+	$(RM) .depend
+
+distclean:
 	$(RM) $(SCRIPTS_GENERATED)
 	$(RM) $(RULESFILES_GENERATED)
-	$(RM) .depend
+
+.PHONY: all install clean distclean depend install_udev_rules
 
 depend:
 	$(CC) $(CFLAGS) -M `ls *.c` > .depend

--- a/utils/sysdeps/Makefile
+++ b/utils/sysdeps/Makefile
@@ -10,6 +10,10 @@ all: $(SYSDEPS_OBJS)
 clean:
 	$(RM) *.o .depend
 
+distclean: ;
+
+.PHONY: all clean distclean depend
+
 depend:
 	$(CC) $(CFLAGS) -M `ls *.c` > .depend
 


### PR DESCRIPTION
This cleans up a little more than "make clean",
in particular removing files generated from templates,
and automake-generated files in iscsiuio.

Also, a ".PHONY:" target was added where needed
so that each Makefile has a complete list of
phony targets.