### PR TITLE
Use config for iscsistart and iscsiadm fw login

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,11 +22,11 @@ MAN8DIR = $(DESTDIR)$(mandir)/man8
 
 MANPAGES_SOURCES	= iscsi_discovery.8 \
 			  iscsi_fw_login.8 \
-			  iscsi-iname.8 \
-			  iscsistart.8
+			  iscsi-iname.8
 MANPAGES_TEMPLATES	= iscsid.8.template \
 			  iscsiadm.8.template \
-			  iscsi-gen-initiatorname.8
+			  iscsi-gen-initiatorname.8 \
+			  iscsistart.8.template
 MANPAGES_GENERATED	= $(MANPAGES_TEMPLATES:.template=)
 MANPAGES_DEST		= $(addprefix $(MAN8DIR)/,$(MANPAGES_GENERATED)) \
 			  $(addprefix $(MAN8DIR)/,$(MANPAGES_SOURCES))

--- a/doc/iscsistart.8.template
+++ b/doc/iscsistart.8.template
@@ -12,6 +12,10 @@ not be run to manage sessions. Its primary use is to start
 sessions used for iSCSI root boot.
 .SH OPTIONS
 .TP
+.BI [-c|--config=]\fIconfig\-file\fP
+Read configuration from \fIconfig\-file\fR rather than the default
+\fI@HOMEDIR@/iscsid.conf\fR file.
+.TP
 .BI [-i|--initiatorname=]\fIname\fP
 Set InitiatorName to name (Required if not using iBFT or OF)
 .TP

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -3864,11 +3864,6 @@ main(int argc, char **argv)
 	if (mode < 0)
 		usage(ISCSI_ERR_INVAL);
 
-	if (mode == MODE_FW) {
-		rc = exec_fw_op(NULL, NULL, info_level, do_login, op, wait, &params);
-		goto out;
-	}
-
 	increase_max_files();
 	if (idbm_init(get_config_file)) {
 		log_warning("exiting due to idbm configuration error");
@@ -3877,6 +3872,9 @@ main(int argc, char **argv)
 	}
 
 	switch (mode) {
+	case MODE_FW:
+		rc = exec_fw_op(NULL, NULL, info_level, do_login, op, wait, &params);
+		break;
 	case MODE_HOST:
 		if (sub_mode != -1) {
 			switch (sub_mode) {


### PR DESCRIPTION
Specifying name-value pairs as arguments to iscsistart or
iscsiadm can become unwieldy very quickly, and is less flexible
than using a config file. If a user desires to update settings,
modifying a config file and rebuilding initramfs can be simpler
than modifying arguments directly in initramfs code or scripts.

Node records created from boot context are populated with
defaults, then any settings specified in a config file are
applied (if config is present).

FW and user-specified params are still applicable. User-specified
name-value arguments are applied after config settings, so they
can serve as a safeguard against config file changes if
desired.

Added -c|--config options for iscsistart to specify the config

Updated iscsistart man page

Signed-off-by: Eric Mackay <eric.mackay@oracle.com>
Reviewed-by: Mike Christie <michael.christie@oracle.com>