### PR TITLE
etc: install system unit with without executable bit

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -81,10 +81,10 @@ install_systemd_service_files: $(DESTDIR)$(systemddir)/system $(SYSTEMD_DEST_SVC
 install_systemd_generator_files: $(DESTDIR)$(systemddir)/system-generators $(SYSTEMD_DEST_GEN_FILES)
 
 $(SYSTEMD_DEST_SVC_FILES): $(DESTDIR)$(systemddir)/system/%: systemd/%
-	$(INSTALL) $? $@
+	$(INSTALL) -m 644 $? $@
 
 $(SYSTEMD_DEST_GEN_FILES): $(DESTDIR)$(systemddir)/system-generators/%: systemd/%
-	$(INSTALL) $? $@
+	$(INSTALL) -m 755 $? $@
 
 install_iname: $(DESTDIR)$(HOMEDIR) $(ISCSI_INAME)
 	if [ ! -f $(INAME_DEST_FILE) ]; then \


### PR DESCRIPTION
All systemd unit files are expected to be not executable, so install
with correct permissions.