### PR TITLE
make: avoid hard-coding path to sed

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ ifeq ($(TOPDIR),)
 	TOPDIR = ..
 endif
 
-SED = /usr/bin/sed
+SED ?= sed
 INSTALL = install
 
 DESTDIR ?=

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -19,7 +19,7 @@ initddir ?= $(etcdir)/init.d
 
 HOMEDIR ?= $(etcdir)/iscsi
 
-SED = /usr/bin/sed
+SED ?= sed
 INSTALL = install
 
 SYSTEMD_SOURCE_FILES	= iscsid.socket iscsiuio.socket

--- a/libopeniscsiusr/Makefile
+++ b/libopeniscsiusr/Makefile
@@ -29,7 +29,7 @@ PKGCONF_DIR ?= $(LIB_DIR)/pkgconfig
 MAN_DIR = $(prefix)/share/man
 
 PKG_CONFIG ?= /usr/bin/pkg-config
-SED ?= /usr/bin/sed
+SED ?= sed
 
 LIBISCSI_USR_DIR=$(TOPDIR)/libopeniscsiusr
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -7,7 +7,7 @@
 # from the top-level make file.
 #
 
-SED = /usr/bin/sed
+SED ?= sed
 INSTALL = install
 CHMOD = chmod
 


### PR DESCRIPTION
Just use PATH to find sed. Not all distributions have moved to a /usr-merged
layout yet.

For Debian I had to patch this, as we still need to build on layouts where sed is (only) in /bin/sed. I think this should work just fine on Fedora, SUSE, etc.