### PR TITLE
Change the calling order of ep_disconnect() and stop_conn()

### DIFF
--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -1032,9 +1032,6 @@ static void iscsi_destroy_session(struct iscsi_session *session)
 		goto done;
 	}
 
-	log_debug(2, "%s ep disconnect", __FUNCTION__);
-	t->template->ep_disconnect(conn);
-
 	log_debug(2, "stop conn");
 	rc = ipc->stop_conn(session->t->handle, session->id,
 			   conn->id, STOP_CONN_TERM);
@@ -1043,6 +1040,9 @@ static void iscsi_destroy_session(struct iscsi_session *session)
 			  session->id, conn->id, rc);
 		goto done;
         }
+
+	log_debug(2, "%s ep disconnect", __FUNCTION__);
+	t->template->ep_disconnect(conn);
 
 	log_debug(2, "%s destroy conn", __FUNCTION__);
         rc = ipc->destroy_conn(session->t->handle, session->id, conn->id);


### PR DESCRIPTION
I got a kernel NULL pointer derference report as below:

    BUG: kernel NULL pointer dereference, address: 0000000000000038
    #PF: supervisor read access in kernel mode
    #PF: error_code(0x0000) - not-present page
    PGD 0 P4D 0
    Oops: 0000 [#1] PREEMPT SMP NOPTI
    CPU: 4 PID: 1050 Comm: cat Not tainted 5.19.0 #38
    RIP: 0010:kernel_getpeername+0xf/0x30
    Call Trace:
     <TASK>
     ? iscsi_sw_tcp_conn_get_param+0x11f/0x17f
     show_conn_ep_param_ISCSI_PARAM_CONN_ADDRESS+0x90/0xb0
     dev_attr_show+0x1d/0x50
     sysfs_kf_seq_show+0xad/0x120
     kernfs_seq_show+0x2c/0x40
     seq_read_iter+0x12e/0x4d0
     ? aa_file_perm+0x177/0x590
     kernfs_fop_read_iter+0x183/0x210
     new_sync_read+0xfe/0x180
     ? 0xffffffff81000000
     vfs_read+0x14d/0x1a0
     ksys_read+0x6d/0xf0
     __x64_sys_read+0x1a/0x20
     do_syscall_64+0x3b/0x90
     entry_SYSCALL_64_after_hwframe+0x63/0xcd

The life cycle of socket is:
login:  ep_connect(create sock)   ---> bind_conn(bind sock to conn)
logout: ep_disconnect(close sock) ---> stop_conn(unbind sock from conn)
The calling order is wrong on logout, will cause this issue in the
following scenarios:

             iscsi logout               get sock param by sysfs
    --------------------------------  ---------------------------
        User Space | Kernel Space             Kernel Space
    --------------------------------  ---------------------------
    session_conn_shutdown
      ep_disconnect
        close(conn->socket_fd)
                     sock_close
                       __sock_release
                         sock->ops = NULL

                                     iscsi_sw_tcp_conn_get_param
                                       sock = tcp_sw_conn->sock;
                                         kernel_getsockname
                                           sock->ops->getname
                                           ^^^^^^^^^
                                           NULL pointer dereference

     ipc->stop_conn
       __kipc_call
                    iscsi_sw_tcp_conn_stop
                      iscsi_sw_tcp_release_conn
                        sock = NULL

So change the calling order of ep_disconnect() and stop_conn() to
fix this issue.

Signed-off-by: Li Jinlin <lijinlin3@huawei.com>