### PR TITLE
Cleanup fwparam makefile

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,4 @@
 iscsi-gen-initiatorname.8
 iscsiadm.8
 iscsid.8
+iscsistart.8

--- a/usr/fwparam_ibft/Makefile
+++ b/usr/fwparam_ibft/Makefile
@@ -39,8 +39,6 @@ CFLAGS += -fPIC $(WARNFLAGS) -I$(TOPDIR)/include -I$(TOPDIR)/usr -D_GNU_SOURCE \
 	  -I$(TOPDIR)/libopeniscsiusr
 CFLAGS += -DSBINDIR=\"$(SBINDIR)\"
 
-LDFLAGS += -L$(TOPDIR)/libopeniscsiusr -liscsiusr
-
 all: $(OBJS)
 
 clean:


### PR DESCRIPTION
Two changes: (1) add generated man pages to git ignore list, and (2) remove dependency on libopeniscsiusr from usr/fwparam_ibft.