### PR TITLE
iscsiuio: Use pthread_t for INVALID_THREAD

### DIFF
--- a/iscsiuio/src/unix/options.h
+++ b/iscsiuio/src/unix/options.h
@@ -86,7 +86,7 @@
 #define DEBUG_ON	0x2
 
 #define INVALID_FD	-1
-#define INVALID_THREAD	-1
+#define INVALID_THREAD	(pthread_t)-1
 #define INVALID_HOST_NO	-1
 
 struct options {


### PR DESCRIPTION
pthread_t is opaque, therefore avoid compiler errors on musl when
compiling since pthread_t is not a plain old data type, like glibc

Signed-off-by: Khem Raj <raj.khem@gmail.com>