### PR TITLE
Don't generate initiatorname when cross-building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -270,6 +270,7 @@ install_data(iscsi_etc_iface_file_src, install_dir: home_dir / 'ifaces')
 install_data(iscsi_etc_config_file_src, install_dir: home_dir)
 
 # create a *unique* initiatorname file
+if not meson.is_cross_build()
   custom_target(
     'initiatorname_file',
     output: 'initiatorname.iscsi',
@@ -278,6 +279,7 @@ install_data(iscsi_etc_config_file_src, install_dir: home_dir)
     install: true,
     install_dir: home_dir,
     install_mode: 'rw-r--r--')
+endif
 
 #
 # handle documentation from 'doc'


### PR DESCRIPTION
Let it be generated by the `iscsi-init` service.