### PR TITLE
libopeniscsiusr: cleanup recent reallocarray->realloc change

### DIFF
--- a/libopeniscsiusr/session.c
+++ b/libopeniscsiusr/session.c
@@ -289,11 +289,15 @@ int iscsi_sessions_get(struct iscsi_context *ctx,
 			rc = LIBISCSI_OK;
 		}
 	}
-	/* reset session count and sessions array length to what we were able to read from sysfs */
+	/*
+	 * reset session count and sessions array length to what we were able to read from sysfs
+	 *
+	 * do not use reallocarray() for the sessions array, since not all platforms
+	 * have that function call
+	 */
 	*session_count = j;
-	/* XXX: asserts that there is no integer overflow */
-	assert(!(sizeof(struct iscsi_session *) &&
-		 *session_count > UINT_MAX / sizeof(struct iscsi_session *)));
+	/* assert that there is no integer overflow in the realloc call */
+	assert(!(*session_count > (UINT_MAX / sizeof(struct iscsi_session *))));
 	*sessions =
 	    realloc(*sessions, *session_count * sizeof(struct iscsi_session *));
 


### PR DESCRIPTION
Just adding more comment, and removing the check
to see if a pointer to a structure is zero.