### PR TITLE
Correctly set the oom_score_adj score value to the equivalent of oom_adj

### DIFF
--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -208,13 +208,17 @@ int get_score_path()
 {
 	int pid;
 	struct stat statb;
-    /* fs/proc/self.c seems to have been introduced > 3.8.rc-1 */
+    
+	/* fs/proc/self.c seems to have been introduced > 3.8.rc-1 */
+	
 	pid = getpid();
 	snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_score_adj", pid);
 	if (stat(path, &statb) == 0)
 	    return -1000;
 	else {
+	
 		/* for kernels older than 2.6.36-rc1*/
+	
 	    snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_adj", pid);
         if (stat(path, &statb) == 0) {
 		    return -17;
@@ -228,18 +232,19 @@ int get_score_path()
 int write_oom_score() 
 {
     int fd;
-	int score_path;
+	int score_path,len;
     char score[12];
 
     score_path = get_score_path();
     if (score_path < 0) {
 		snprintf(score, 12, "%d", score_path);
+		len = strlen(score);
 		fd = open(path, O_WRONLY);
 		if (fd < 0) {
 		    LOG_DEBUG("Could not open %s for writing: %s", path, strerror(errno))
 		    return -1;
 		}
-		else if (write(fd, score, 3) < 0) {
+		else if (write(fd, score, len) < 0) {
 			LOG_DEBUG("Could not write score to %s: %s", path, strerror(errno))
 			close(fd);
 			return -1;

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -225,8 +225,8 @@ int oom_adjust(void)
 	if (write(fd, "-16", 3) < 0) /* for 2.6.11 */
 		LOG_DEBUG("Could not set oom score to -16: %s",
 			  strerror(errno));
-	if (write(fd, "-17", 3) < 0) /* for Andrea's patch */
-		LOG_DEBUG("Could not set oom score to -17: %s",
+	if (write(fd, "-1000", 3) < 0) /* for Andrea's patch */
+		LOG_DEBUG("Could not set oom score adj to -1000: %s",
 			  strerror(errno));
 	close(fd);
 	return 0;

--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -97,18 +97,19 @@ int get_score_path()
 int write_oom_score() 
 {
     int fd;
-	int score_path;
+	int score_path,len;
     char score[12];
 
     score_path = get_score_path();
     if (score_path < 0) {
 		snprintf(score, 12, "%d", score_path);
+		len = strlen(score);
 		fd = open(path, O_WRONLY);
 		if (fd < 0) {
 		    LOG_DEBUG("Could not open %s for writing: %s", path, strerror(errno))
 		    return -1;
 		}
-		else if (write(fd, score, 3) < 0) {
+		else if (write(fd, score, len) < 0) {
 			LOG_DEBUG("Could not write score to %s: %s", path, strerror(errno))
 			close(fd);
 			return -1;

--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -67,35 +67,70 @@ void daemon_init(void)
 
 #define ISCSI_OOM_PATH_LEN 48
 
-int oom_adjust(void)
+char path[ISCSI_OOM_PATH_LEN];
+
+int get_score_path() 
 {
-	int fd;
-	char path[ISCSI_OOM_PATH_LEN];
+	int pid;
 	struct stat statb;
+    
+	/* fs/proc/self.c seems to have been introduced > 3.8.rc-1 */
+	
+	pid = getpid();
+	snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_score_adj", pid);
+	if (stat(path, &statb) == 0)
+	    return -1000;
+	else {
 
-	errno = 0;
-	if (nice(-10) == -1 && errno != 0)
-		log_debug(1, "Could not increase process priority: %s",
-			  strerror(errno));
-
-	snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_score_adj", getpid());
-	if (stat(path, &statb)) {
-		/* older kernel so use old oom_adj file */
-		snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_adj",
-			 getpid());
+		/* for kernels older than 2.6.36-rc1*/
+		
+	    snprintf(path, ISCSI_OOM_PATH_LEN, "/proc/%d/oom_adj", pid);
+        if (stat(path, &statb) == 0) {
+		    return -17;
+		}
+		else
+		    LOG_DEBUG("Could not find oom score adjustment file in /proc: %s", strerror(errno));
 	}
-	fd = open(path, O_WRONLY);
-	if (fd < 0)
-		return -1;
-	if (write(fd, "-16", 3) < 0) /* for 2.6.11 */
-		log_debug(1, "Could not set oom score to -16: %s",
-			  strerror(errno));
-	if (write(fd, "-1000", 3) < 0) /* for Andrea's patch */
-		log_debug(1, "Could not set oom score adj to -1000: %s",
-			  strerror(errno));
-	close(fd);
 	return 0;
 }
+
+int write_oom_score() 
+{
+    int fd;
+	int score_path;
+    char score[12];
+
+    score_path = get_score_path();
+    if (score_path < 0) {
+		snprintf(score, 12, "%d", score_path);
+		fd = open(path, O_WRONLY);
+		if (fd < 0) {
+		    LOG_DEBUG("Could not open %s for writing: %s", path, strerror(errno))
+		    return -1;
+		}
+		else if (write(fd, score, 3) < 0) {
+			LOG_DEBUG("Could not write score to %s: %s", path, strerror(errno))
+			close(fd);
+			return -1;
+		}
+		else
+		    close(fd);
+	}
+	return 0;
+}
+
+int oom_adjust(void)
+{
+	if (nice(-10) < 0)
+		LOG_DEBUG("Could not increase process priority: %s",
+			  strerror(errno));
+
+    if (write_oom_score() < 0)
+	    LOG_DEBUG("Could not adjust oom score.");
+
+	return 0;
+}
+
 
 char*
 str_to_ipport(char *str, int *port, int *tpgt)

--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -90,8 +90,8 @@ int oom_adjust(void)
 	if (write(fd, "-16", 3) < 0) /* for 2.6.11 */
 		log_debug(1, "Could not set oom score to -16: %s",
 			  strerror(errno));
-	if (write(fd, "-17", 3) < 0) /* for Andrea's patch */
-		log_debug(1, "Could not set oom score to -17: %s",
+	if (write(fd, "-1000", 3) < 0) /* for Andrea's patch */
+		log_debug(1, "Could not set oom score adj to -1000: %s",
 			  strerror(errno));
 	close(fd);
 	return 0;


### PR DESCRIPTION
It looks like when the change to new path was made the value used was the expected for oom_adj but oom_score_adj uses values between -1000 and 1000, so it looks like with the same intention in mind ( avoid killing iscsid when oom_killer is invoked ), the value should be -1000. 
This is according to https://www.kernel.org/doc/Documentation/filesystems/proc.rst , section 3.1, OOM_SCORE_ADJ_MIN, which under a regular kernel release should be -1000 ( https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/oom.h )
Quoting:  "The lowest possible value, -1000, is equivalent to disabling oom killing entirely for that task since it will always report a badness score of 0."