### PR TITLE
Adapt for intalling by copying an existing system

### DIFF
--- a/etc/systemd/iscsid.service.template
+++ b/etc/systemd/iscsid.service.template
@@ -10,6 +10,7 @@ Requires=iscsi-init.service
 [Service]
 Type=notify
 NotifyAccess=main
+ExecStartPre=/bin/sh -c 'if ! test -e @HOMEDIR@/initiatorname.iscsi; then exec @SBINDIR@/iscsi-gen-initiatorname; fi'
 ExecStart=@SBINDIR@/iscsid -f
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
Currently the SUSE open-iscsi package [1] has the following postinstall scriptlet:

%post
<...>
if [ ! -f %{_sysconfdir}/iscsi/initiatorname.iscsi ] ; then
    %{_iscsi_sbindir}/iscsi-gen-initiatorname
fi

[1] https://build.opensuse.org/package/view_file/network/open-iscsi/open-iscsi.spec?expand=1&rev=1c62509c1088f8831edc05535ab8c190

It is bad for cases when an existing system is copied to a new destination:
* cloning by dd, rsync, Clonezilla etc.
* installing from an ISO image by rsync (that is how ROSA Linux is installed)

I have been updating the ROSA open-iscsi package [2] and noticed that, if I unclude it into the ISO (and I am going to do this), all installed systems will have the same content of this file because a ready to use image is copied by rsync by Anaconda installer.

[2] https://abf.io/import/open-iscsi