### PR TITLE
iscsid: clear scanning thread's PR_SET_IO_FLUSHER flag

### DIFF
--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -40,6 +40,7 @@
 #include "host.h"
 #include "iscsi_err.h"
 #include "flashnode.h"
+#include "iscsi_util.h"
 
 /*
  * TODO: remove the _DIR defines and search for subsys dirs like
@@ -1993,6 +1994,12 @@ pid_t iscsi_sysfs_scan_host(int hostno, int async, int autoscan)
 	} else if (pid == 0) {
 		/* child */
 		log_debug(4, "scanning host%d", hostno);
+
+		/*
+		 * The return value of init_thread_io_flusher would not
+		 * affect the scan flow, so just ignore it.
+		 */
+		set_thread_io_flusher(0);
 
 		snprintf(id, sizeof(id), ISCSI_HOST_ID, hostno);
 		sysfs_set_param(id, SCSI_HOST_SUBSYS, "scan", write_buf,

--- a/usr/iscsi_util.h
+++ b/usr/iscsi_util.h
@@ -20,6 +20,7 @@ extern int __iscsi_match_session(struct node_rec *rec, char *targetname,
 				 char *address, int port,
 				 struct iface_rec *iface,
 				 unsigned sid);
+extern int set_thread_io_flusher(int val);
 
 #define MATCH_ANY_SID 0
 


### PR DESCRIPTION
commit 72949ef (iscsid: set PR_SET_IO_FLUSHER) set the iscsid's PR_SET_IO_FLUSHER flag to avoid deadlock. While we do not need to set this flag when scanning host.

If this flag is set for scanning thread, we may lost devices reported by target because of memory allocation failure.

Reference: #381 

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>