### PR TITLE
Build(meson): ensure binaries use our library.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ foreach a,v: test_arr
   e = executable('test_' + a,
     sources: v,
     include_directories: [lib_inc],
+    link_with: libiscsi_usr,
     dependencies: libiscsi_usr_dep,
     c_args: genl_cargs)
   test('test ' + a, e)
@@ -190,6 +191,7 @@ foreach k,v: iscsi_usr_arr
     include_directories: [usr_inc, main_inc, lib_inc],
     dependencies: usr_deps,
     c_args: genl_cargs,
+    link_with: libiscsi_usr,
     install: true,
     install_dir: iscsi_sbindir)
 endforeach

--- a/usr/meson.build
+++ b/usr/meson.build
@@ -1,6 +1,6 @@
 subdir('fwparam_ibft')
 
-iscsi_lib_srcs = [
+iscsi_usr_srcs = [
   'iscsi_util.c',
   'io.c',
   'auth.c',
@@ -46,9 +46,9 @@ iscsiadm_srcs = [
 iscsistart_srcs = [
   'iscsistart.c']
 
-iscsid_src_files = files([iscsi_lib_srcs, initiator_srcs, discovery_srcs, iscsid_srcs])
-iscsiadm_src_files = files([iscsi_lib_srcs, discovery_srcs, iscsiadm_srcs])
-iscsistart_src_files = files([iscsi_lib_srcs, initiator_srcs, iscsistart_srcs])
+iscsid_src_files = files([initiator_srcs, discovery_srcs, iscsid_srcs, iscsi_usr_srcs])
+iscsiadm_src_files = files([discovery_srcs, iscsiadm_srcs, iscsi_usr_srcs])
+iscsistart_src_files = files([initiator_srcs, iscsistart_srcs, iscsi_usr_srcs])
 
 iscsi_usr_arr = {
   'iscsid': iscsid_src_files,


### PR DESCRIPTION
Ensure that iscsid, iscsiadm, and iscsistart link
against libopeniscsiusr.so. Also, rename meson
list of "usr/" source files to be less confusing.