### PR TITLE
iscsid.conf: remove incorrect comment about location

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -1,6 +1,5 @@
 #
 # Open-iSCSI default configuration.
-# Could be located at /etc/iscsi/iscsid.conf or ~/.iscsid.conf
 #
 # Note: To set any of these values for a specific node/session run
 # the iscsiadm --mode node --op command for the value. See the README


### PR DESCRIPTION
Remove the comment in the config file saying where it might be located, since it was incorrect, and
users already know where it's located if they are
reading the comment.