### PR TITLE
Avoid forcing remote-fs-pre after network-online if possible.

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -27,6 +27,7 @@ SYSTEMD_SOURCES		= $(addprefix systemd/,$(SYSTEMD_SOURCE_FILES))
 SYSTEMD_TEMPLATE_FILES	= iscsi-init.service.template \
 			  iscsid.service.template \
 			  iscsi.service.template \
+			  iscsi-starter.service.template \
 			  iscsiuio.service.template
 SYSTEMD_TEMPLATES	= $(addprefix systemd/,$(SYSTEMD_TEMPLATE_FILES))
 SYSTEMD_RULES_FILES	= ibft-rule-generator

--- a/etc/systemd/iscsi-starter.service.template
+++ b/etc/systemd/iscsi-starter.service.template
@@ -1,0 +1,13 @@
+[Unit]
+DefaultDependencies=no
+Before=sysinit.target iscsi.service
+RequiresMountsFor=/var/lib/iscsi/nodes
+ConditionDirectoryNotEmpty=/var/lib/iscsi/nodes
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=@SBINDIR@/systemctl start --no-block --job-mode=fail iscsi.service
+
+[Install]
+WantedBy=sysinit.target

--- a/etc/systemd/iscsi.service.template
+++ b/etc/systemd/iscsi.service.template
@@ -15,4 +15,4 @@ SuccessExitStatus=21 15
 RemainAfterExit=true
 
 [Install]
-WantedBy=remote-fs.target
+Also=iscsi-starter.service


### PR DESCRIPTION
Currently, when iscsi.service is installed, it creates an ordering dependency that forces network-online to start before remote-fs-pre.target, which delays boot even when /var/lib/iscsi/nodes is empty and the iscsi.service won't be started.  This change moves the logic that determines whether iscsi will be started to an external service file so that the boot order dependency exists only when iscsi.service will be started.