### PR TITLE
Make UID the default auth type for IPCs

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -31,10 +31,11 @@
 # iscsid.safe_logout = Yes
 
 # Only require UID auth for MGMT IPCs, and not username.
-# Useful if you want to run iscsid in a constrained environment.
-# Note: Only do this if you are aware of the security implications.
-# Defaults to "No".
-# iscsid.ipc_auth_uid = Yes
+# Checking username is a legacy security practice, and is on the path
+# to deprecation.
+# Set to "No" for legacy compatibility.
+# Defaults to "Yes".
+# iscsid.ipc_auth_uid = No
 
 #############################
 # NIC/HBA and driver settings

--- a/usr/event_poll.c
+++ b/usr/event_poll.c
@@ -197,8 +197,8 @@ void event_loop(struct iscsi_ipc *ipc, int control_fd, int mgmt_ipc_fd)
 
 			if (poll_array[POLL_IPC].revents) {
 				switch (ipc->auth_type) {
-				case ISCSI_IPC_AUTH_UID:
-					mgmt_ipc_handle_uid_only(mgmt_ipc_fd);
+				case ISCSI_IPC_AUTH_LEGACY:
+					mgmt_ipc_handle_legacy(mgmt_ipc_fd);
 					break;
 				default:
 					mgmt_ipc_handle(mgmt_ipc_fd);

--- a/usr/iscsi_ipc.h
+++ b/usr/iscsi_ipc.h
@@ -53,11 +53,11 @@ struct iscsi_ipc_ev_clbk {
 extern void ipc_register_ev_callback(struct iscsi_ipc_ev_clbk *ipc_ev_clbk);
 
 enum iscsi_ipc_auth_type {
-	/* UID must have valid entry in user db */
-	ISCSI_IPC_AUTH_DEFAULT = 0,
-
 	/* Check only that UID==0 */
-	ISCSI_IPC_AUTH_UID,
+	ISCSI_IPC_AUTH_UID = 0,
+
+	/* Check UID, and check user db entries for matching username. Legacy mode. */
+	ISCSI_IPC_AUTH_LEGACY = 1,
 
 	/* Must be last */
 	ISCSI_IPC_AUTH_MAX,

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -579,9 +579,11 @@ int main(int argc, char *argv[])
 		daemon_config.safe_logout = 1;
 	free(safe_logout);
 
+	/* This is now the default, but still setting it explicitly for clarity */
+	ipc->auth_type = ISCSI_IPC_AUTH_UID;
 	ipc_auth_uid = cfg_get_string_param(config_file, "iscsid.ipc_auth_uid");
-	if (ipc_auth_uid && !strcmp(ipc_auth_uid, "Yes"))
-		ipc->auth_type = ISCSI_IPC_AUTH_UID;
+	if (ipc_auth_uid && !strcmp(ipc_auth_uid, "No"))
+		ipc->auth_type = ISCSI_IPC_AUTH_LEGACY;
 	free(ipc_auth_uid);
 
 	/* see if we have any stale sessions to recover */

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -548,6 +548,7 @@ int main(int argc, char *argv[])
 	log_debug(1, "TPGT=%d", config_rec.tpgt);
 	log_debug(1, "IP Address=%s", config_rec.conn[0].address);
 
+	/* This is now the default, but still setting it explicitly for clarity */
 	ipc->auth_type = ISCSI_IPC_AUTH_UID;
 
 	/* log the version, so that we can tell if the daemon and kernel module

--- a/usr/mgmt_ipc.h
+++ b/usr/mgmt_ipc.h
@@ -115,6 +115,6 @@ int mgmt_ipc_listen(void);
 int mgmt_ipc_systemd(void);
 void mgmt_ipc_close(int fd);
 void mgmt_ipc_handle(int accept_fd);
-void mgmt_ipc_handle_uid_only(int accept_fd);
+void mgmt_ipc_handle_legacy(int accept_fd);
 
 #endif /* MGMT_IPC_H */


### PR DESCRIPTION
Modern security practices include checking the originating UID of an IPC. But not the username, as there are many valid scenarios where a user database may not exist or the root account may not be explicitly named "root".

The mode to check UID and username is still functional, but is now on the path to deprecation. Related function names and enums now include the term "legacy" to indicate this deprecated status.

The 'iscsid.ipc_auth_uid' setting in iscsid.config now defaults to 'Yes', rather than introducing a new key. Users sometimes keep old config files when upgrading packages, and this ensures behavior remains the same if this setting was explicitly defined in an old config.

Signed-off-by: Eric Mackay <eric.mackay@oracle.com>
Reviewed-by: Mike Christie <michael.christie@oracle.com>