### PR TITLE
Build: make open-isns usage optional.

### DIFF
--- a/README
+++ b/README
@@ -88,7 +88,8 @@ As of today, the Open-iSCSI Initiator requires a host running the
 Linux operating system with kernel.
 
 The userspace components iscsid, iscsiadm and iscsistart require the
-open-isns library.
+open-isns library, unless open-isns use is diabled when building (see
+below).
 
 If this package is not available for your distribution, you can download
 and install it yourself.  To install the open-isns headers and library
@@ -142,24 +143,29 @@ MESON-OPTIONS:
 --------------
 One can override several default values when building with meson:
 
-- Library files are installed in /lib64 by default, but this
-  can be overridden by passing '--libdir=<LIBDIR>' to meson.
 
-- Extra flags can be passed to the C compiler using '-Dc_flags="<C-FLAGS>"'.
+Option			Description
+=====================	=====================================================
 
-- In newer version of meson (>=0.63) you can override location where binaries
-  are installed, which by default is "/usr/sbin", using the '--sbindir=<DIR>'
-  option to meson.
+--libdir=<LIBDIR>	Where library files go [/lib64]
+--sbindir=<DIR>		Meson 0.63 or newer: Where binaries go [/usr/sbin]
+-Dc_flags="<C-FLAGS>"	Add in addition flags to the C compiler
+-Dno_systemd=<BOOL>	Enables systemd usage [false]
+			(set to "true" to disable systemd)
+-Dsystemddir=<DIR>	Set systemd unit directory [/usr/lib/systemd]
+-Dhomedir=<DIR>		Set config file directory [/etc/iscsi]
+-Ddbroot=<DIR>		Set Database directory [/etciscsi]
+-Dlockdir=<DIR>		Set Lock directory [/run/lock/iscsi]
+-Drulesdir=<DIR>	Set udev rules directory [/usr/lib/udev/rules.d]
+-Discsi_sbindir=<DIR>	Where binaries go [/usr/sbin]
+			(for use when sbindir can't be set, in older versions
+			 of meson)
+-Disns_supported=<BOOL>	Enable/disable iSNS support [true]
+			(set to "false" to disable use of open-isns)
 
-- The default "home" directory is "/etc/iscsi", but this can be overridden
-  using '-Dhomedir=<SOMEDIR>'. This is where the configuration files are kept
 
-- The default "database" directory is also "/etc/iscsi", but can be
-  overridden using '-Ddbroot=<SOMEDIR>'
-
-
-Building open-iscsi/iscsiuio using make/autoconf
-------------------------------------------------
+Building open-iscsi/iscsiuio using make/autoconf (Deprecated)
+-------------------------------------------------------------
 If you wish to build using the older deprecated system, you can
 simply run:
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,18 +15,20 @@ etcdir = /etc
 DBROOT ?= $(etcdir)/iscsi
 HOMEDIR ?= $(etcdir)/iscsi
 
+IQN_PREFIX ?= "iqn.2016-04.com.open-iscsi"
+
 prefix ?= /usr
 mandir ?= $(prefix)/share/man
 
 MAN8DIR = $(DESTDIR)$(mandir)/man8
 
 MANPAGES_SOURCES	= iscsi_discovery.8 \
-			  iscsi_fw_login.8 \
-			  iscsi-iname.8
+			  iscsi_fw_login.8
 MANPAGES_TEMPLATES	= iscsid.8.template \
 			  iscsiadm.8.template \
 			  iscsi-gen-initiatorname.8 \
-			  iscsistart.8.template
+			  iscsistart.8.template \
+			  iscsi-iname.8.template
 MANPAGES_GENERATED	= $(MANPAGES_TEMPLATES:.template=)
 MANPAGES_DEST		= $(addprefix $(MAN8DIR)/,$(MANPAGES_GENERATED)) \
 			  $(addprefix $(MAN8DIR)/,$(MANPAGES_SOURCES))
@@ -38,7 +40,7 @@ install: install_doc
 install_doc: $(MAN8DIR) $(MANPAGES_DEST)
 
 $(MANPAGES_GENERATED): %.8: %.8.template
-	$(SED) -e 's:@HOMEDIR@:$(HOMEDIR):' -e 's:@DBROOT@:$(DBROOT):' $? > $@
+	$(SED) -e 's:@HOMEDIR@:$(HOMEDIR):' -e 's:@DBROOT@:$(DBROOT):' -e 's:@IQN_PREFIX@:$(IQN_PREFIX):' $? > $@
 
 $(MANPAGES_DEST): $(MAN8DIR)/%: %
 	$(INSTALL) -m 644 $? $@

--- a/doc/iscsi-iname.8.template
+++ b/doc/iscsi-iname.8.template
@@ -14,7 +14,7 @@ generates a unique iSCSI node name on every invocation.
 Display help
 .TP
 .BI [-p=]\fIprefix\fP
-Use the prefix passed in instead of the default "iqn.2016-04.com.open-iscsi"
+Use the prefix passed in instead of the default "@IQN_PREFIX@"
 
 .SH AUTHORS
 Open-iSCSI project <http://www.open-iscsi.com/>

--- a/doc/iscsiadm.8.template
+++ b/doc/iscsiadm.8.template
@@ -464,7 +464,7 @@ This option is only valid for \fInode\fR and \fIsession\fR mode.
 .TP
 \fB\-t\fR, \fB\-\-type=\fItype\fR
 \fItype\fR must be \fIsendtargets\fR (or abbreviated as \fIst\fR),
-\fIisns\fR, or \fIfw\fR. See the \fBDISCOVERY TYPES\fR section.
+\fIisns\fR (if enabled), or \fIfw\fR. See the \fBDISCOVERY TYPES\fR section.
 .IP
 This option is only valid for \fIdiscovery\fR mode.
 .TP
@@ -495,6 +495,7 @@ This option is only valid for \fIchap\fR and \fIflashnode\fR submodes of \fIhost
 .SH DISCOVERY TYPES
 iSCSI defines 3 discovery types: \fISendTargets\fR, \fISLP\fR, and \fIiSNS\fR.
 \fISLP\fR is not widely supported, and not supported by this pacakge.
+\fiSNS\fR supported depends on build options, but is enabled by default.
 .PP
 A special discovery type called
 .I fw

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -3,15 +3,15 @@
 # static man pages
 iscsi_doc_man_pages_static = files([
   'iscsi_discovery.8',
-  'iscsi_fw_login.8',
-  'iscsi-iname.8'])
+  'iscsi_fw_login.8'])
 
 # template man pages
 iscsi_doc_man_pages_templates = [
   'iscsid',
   'iscsiadm',
   'iscsi-gen-initiatorname',
-  'iscsistart']
+  'iscsistart',
+  'iscsi-iname']
 iscsi_doc_man_pages_template_arr = {}
 foreach t: iscsi_doc_man_pages_templates
   iscsi_doc_man_pages_template_arr += {t + '.8': files(t + '.8.template')}

--- a/meson.build
+++ b/meson.build
@@ -186,13 +186,17 @@ usr_deps = [kmod_dep, crypto_dep, mount_dep, sysdeps_dep, fwparam_dep, libiscsi_
 if not no_systemd
   usr_deps += systemd_dep
 endif
-if get_option('isns').enabled()
-  genl_cargs += '-DISNS_SUPPORTED'
-endif
-
 # handle two libs that won't be found with "dependency()"
 usr_deps += cc.find_library('rt')
 usr_deps += cc.find_library('isns', required: get_option('isns'))
+
+# Do we want to support iSNS?
+# NOTE: we could just use "get_option('isns').enabled() here,
+# but checking to see if the library was indeed found
+# seems better
+if cc.find_library('isns', required: get_option('isns')).found()
+  genl_cargs += '-DISNS_SUPPORTED'
+endif
 
 # build iscsid, iscsiadm, and iscsistart
 foreach k,v: iscsi_usr_arr

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ endif
 c_args = get_option('c_args')
 man_dir = get_option('mandir')
 iscsi_sbindir = get_option('iscsi_sbindir')
+iqn_prefix = get_option('iqn_prefix')
 
 #
 # get list of sources from subdirs (iscsiuio included at bottom)
@@ -56,6 +57,7 @@ conf = configuration_data()
 conf.set('SBINDIR', iscsi_sbindir)
 conf.set('HOMEDIR', home_dir)
 conf.set('DBROOT', db_root)
+conf.set('IQN_PREFIX', iqn_prefix)
 
 
 # set up general C args
@@ -65,7 +67,8 @@ genl_cargs = [
   '-DISCSI_CONFIG_ROOT="@0@"'.format(home_dir),
   '-DISCSI_DB_ROOT="@0@"'.format(db_root),
   '-DLOCK_DIR="@0@"'.format(lock_dir),
-  '-DISCSI_VERSION_STR="@0@"'.format(meson.project_version())]
+  '-DISCSI_VERSION_STR="@0@"'.format(meson.project_version()),
+  '-DISCSI_NAME_PREFIX="@0@"'.format(iqn_prefix)]
 
 # set up no-system flag, if needed
 if no_systemd

--- a/meson.build
+++ b/meson.build
@@ -183,10 +183,13 @@ usr_deps = [kmod_dep, crypto_dep, mount_dep, sysdeps_dep, fwparam_dep, libiscsi_
 if not no_systemd
   usr_deps += systemd_dep
 endif
+if get_option('isns').enabled()
+  genl_cargs += '-DISNS_SUPPORTED'
+endif
 
 # handle two libs that won't be found with "dependency()"
 usr_deps += cc.find_library('rt')
-usr_deps += cc.find_library('isns')
+usr_deps += cc.find_library('isns', required: get_option('isns'))
 
 # build iscsid, iscsiadm, and iscsistart
 foreach k,v: iscsi_usr_arr

--- a/meson.build
+++ b/meson.build
@@ -190,10 +190,7 @@ endif
 usr_deps += cc.find_library('rt')
 usr_deps += cc.find_library('isns', required: get_option('isns'))
 
-# Do we want to support iSNS?
-# NOTE: we could just use "get_option('isns').enabled() here,
-# but checking to see if the library was indeed found
-# seems better
+# is the isns library present?
 if cc.find_library('isns', required: get_option('isns')).found()
   genl_cargs += '-DISNS_SUPPORTED'
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,10 @@ option('no_systemd', type: 'boolean', value: false,
 option('systemddir', type: 'string', value: '/usr/lib/systemd',
   description: 'Systemd directory [/usr/lib/systemd], if systemd used')
 
+# is open-isns supporte?
+option('isns', type: 'feature', value: 'enabled',
+  description: 'Use open-isns to allow target discovery via iSNS')
+
 # these are in the 'sysconfigdir' (/etc by default) unless overridden
 option('homedir', type: 'string', value: 'iscsi',
   description: 'Set the HOME directory [/etc/iscsi]')
@@ -21,3 +25,4 @@ option('rulesdir', type: 'string', value: 'udev/rules.d',
 # older version of meson do not allow overriding sbindir
 option('iscsi_sbindir', type: 'string', value: '/usr/sbin',
   description: 'Set the directory where our binaries go [/usr/sbin]')
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,3 +26,6 @@ option('rulesdir', type: 'string', value: 'udev/rules.d',
 option('iscsi_sbindir', type: 'string', value: '/usr/sbin',
   description: 'Set the directory where our binaries go [/usr/sbin]')
 
+# default iqn prefix use for iscsi-iname
+option('iqn_prefix', type: 'string', value: 'iqn.2016-04.com.open-iscsi',
+  description: 'Set the prefix used by iscsi-iname to generate iSCSI names')

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -50,6 +50,7 @@ CFLAGS += $(WARNFLAGS) -I../include -I. -D_GNU_SOURCE \
 	  -DISCSI_VERSION_STR=\"$(ISCSI_VERSION_STR)\"
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libkmod)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd)
+CFLAGS += -DISNS_SUPPORTED
 ISCSI_LIB = -L$(TOPDIR)/libopeniscsiusr -lopeniscsiusr
 LDFLAGS += $(shell $(PKG_CONFIG) --libs libkmod)
 ifeq ($(NO_SYSTEMD),)

--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -49,10 +49,12 @@
 #include "iface.h"
 #include "iscsi_timer.h"
 #include "iscsi_err.h"
+#if ISNS_SUPPORTED
 /* libisns includes */
 #include <libisns/isns.h>
 #include <libisns/paths.h>
 #include <libisns/message.h>
+#endif
 
 #define DISCOVERY_NEED_RECONNECT 0xdead0001
 
@@ -94,6 +96,7 @@ static int request_initiator_name(int tmo)
 	return 0;
 }
 
+#ifdef ISNS_SUPPORTED
 void discovery_isns_free_servername(void)
 {
 	if (isns_config.ic_server_name)
@@ -371,6 +374,7 @@ retry:
 	discovery_isns_free_servername();
 	return rc;
 }
+#endif	/* ISNS_SUPPORTED */
 
 int discovery_fw(void *data,
 		 __attribute__((unused))struct iface_rec *iface,

--- a/usr/discovery.h
+++ b/usr/discovery.h
@@ -27,6 +27,7 @@ struct iface_rec;
 struct node_rec;
 struct boot_context;
 
+#ifdef ISNS_SUPPORTED
 extern int discovery_isns_query(struct discovery_rec *drec, const char *iname,
 				const char *targetname,
 				struct list_head *rec_list);
@@ -34,6 +35,7 @@ extern void discovery_isns_free_servername(void);
 extern int discovery_isns_set_servername(char *address, int port);
 extern int discovery_isns(void *data, struct iface_rec *iface,
 			  struct list_head *rec_list);
+#endif
 extern int discovery_fw(void *data, struct iface_rec *iface,
 			struct list_head *rec_list);
 extern int discovery_sendtargets(void *data, struct iface_rec *iface,

--- a/usr/discoveryd.c
+++ b/usr/discoveryd.c
@@ -41,16 +41,19 @@
 #include "session_mgmt.h"
 #include "session_info.h"
 #include "iscsi_err.h"
+#ifdef ISNS_SUPPORTED
 #include <libisns/isns-proto.h>
 #include <libisns/isns.h>
 #include <libisns/paths.h>
 #include <libisns/message.h>
+#endif
 
 #define DISC_DEF_POLL_INVL	30
 
 static LIST_HEAD(iscsi_targets);
 static int stop_discoveryd;
 
+#ifdef ISNS_SUPPORTED
 static LIST_HEAD(isns_initiators);
 static LIST_HEAD(isns_refresh_list);
 static char *isns_entity_id = NULL;
@@ -58,6 +61,7 @@ static uint32_t isns_refresh_interval;
 static int isns_register_nodes = 1;
 
 static void isns_reg_refresh_by_eid_qry(void *data);
+#endif
 
 typedef void (do_disc_and_login_fn)(const char *def_iname,
 				    struct discovery_rec *drec, int poll_inval);
@@ -158,8 +162,10 @@ static void update_sessions(struct list_head *new_rec_list,
 			if (strlen(rec->iface.iname) &&
 			    strcmp(rec->iface.iname, iname))
 				continue;
+#ifdef ISNS_SUPPORTED
 			else if (strcmp(iname, isns_config.ic_source_name))
 				continue;
+#endif
 		}
 
 		log_debug(5, "Matched %s %s, checking if in new targets.",
@@ -219,6 +225,8 @@ static void fork_disc(const char *def_iname, struct discovery_rec *drec,
 		reap_inc();
 	}
 }
+
+#ifdef ISNS_SUPPORTED
 
 struct isns_node_list {
 	isns_source_t *source;
@@ -1018,6 +1026,7 @@ static void start_isns(const char *def_iname, struct discovery_rec *drec,
 	log_debug(1, "start isns done %d.", rc);
 	discoveryd_stop();
 }
+#endif	/* ISNS_SUPPORTED */
 
 /* SendTargets */
 static void __do_st_disc_and_login(struct discovery_rec *drec)
@@ -1087,6 +1096,7 @@ static void discoveryd_st_start(void)
 	idbm_for_each_st_drec(NULL, st_start);
 }
 
+#ifdef ISNS_SUPPORTED
 static int isns_start(void *data, struct discovery_rec *drec)
 {
 	log_debug(1, "isns_start %s:%d %d", drec->address, drec->port,
@@ -1102,9 +1112,12 @@ static void discoveryd_isns_start(const char *def_iname)
 {
 	idbm_for_each_isns_drec((void *)def_iname, isns_start);
 }
+#endif	/* ISNS_SUPPORTED */
 
 void discoveryd_start(const char *def_iname)
 {
+#ifdef ISNS_SUPPORTED
 	discoveryd_isns_start(def_iname);
+#endif
 	discoveryd_st_start();
 }

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -52,7 +52,9 @@
 #include "idbm_fields.h"
 #include "session_mgmt.h"
 #include "iscsid_req.h"
+#ifdef ISNS_SUPPORTED
 #include <libisns/isns-proto.h>
+#endif
 #include "iscsi_err.h"
 #include "iscsi_ipc.h"
 #include "iscsi_timer.h"
@@ -257,8 +259,10 @@ str_to_type(char *str)
 	if (!strcmp("sendtargets", str) ||
 	    !strcmp("st", str))
 		type = DISCOVERY_TYPE_SENDTARGETS;
+#ifdef ISNS_SUPPORTED
 	else if (!strcmp("isns", str))
 		type = DISCOVERY_TYPE_ISNS;
+#endif
 	else if (!strcmp("fw", str))
 		type = DISCOVERY_TYPE_FW;
 	else
@@ -1238,6 +1242,7 @@ do_software_sendtargets(discovery_rec_t *drec, struct list_head *ifaces,
 	return rc;
 }
 
+#ifdef ISNS_SUPPORTED
 static int do_isns(discovery_rec_t *drec, struct list_head *ifaces,
 		   int info_level, int do_login, int op)
 {
@@ -1273,6 +1278,7 @@ static int do_isns(discovery_rec_t *drec, struct list_head *ifaces,
 
 	return rc;
 }
+#endif	/* ISNS_SUPPORTED */
 
 static int
 do_target_discovery(discovery_rec_t *drec, struct list_head *ifaces,
@@ -1335,8 +1341,10 @@ sw_discovery:
 	case DISCOVERY_TYPE_SENDTARGETS:
 		return do_software_sendtargets(drec, ifaces, info_level,
 						do_login, op, sync_drec);
+#ifdef ISNS_SUPPORTED
 	case DISCOVERY_TYPE_ISNS:
 		return do_isns(drec, ifaces, info_level, do_login, op);
+#endif
 	default:
 		log_debug(1, "Unknown Discovery Type : %d", drec->type);
 		return ISCSI_ERR_UNKNOWN_DISCOVERY_TYPE;
@@ -3241,6 +3249,7 @@ static int exec_disc2_op(int disc_type, char *ip, int port,
 		if (rc < 0)
 			goto do_db_op;
 		goto done;
+#ifdef ISNS_SUPPORTED
 	case DISCOVERY_TYPE_ISNS:
 		if (port < 0)
 			port = ISNS_DEFAULT_PORT;
@@ -3250,6 +3259,7 @@ static int exec_disc2_op(int disc_type, char *ip, int port,
 		if (rc < 0)
 			goto do_db_op;
 		goto done;
+#endif
 	case DISCOVERY_TYPE_FW:
 		if (!do_discover) {
 			log_error("Invalid command. Possibly missing "
@@ -3351,6 +3361,7 @@ static int exec_disc_op(int disc_type,
 		if (rc)
 			goto done;
 		break;
+#ifdef ISNS_SUPPORTED
 	case DISCOVERY_TYPE_ISNS:
 		if (!ip) {
 			log_error("Please specify portal as "
@@ -3371,6 +3382,7 @@ static int exec_disc_op(int disc_type,
 		if (rc)
 			goto done;
 		break;
+#endif
 	case DISCOVERY_TYPE_FW:
 		drec.type = DISCOVERY_TYPE_FW;
 		rc = exec_fw_op(&drec, ifaces, info_level, do_login, op, wait, NULL);

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -18,8 +18,11 @@ HOMEDIR ?= $(etcdir)/iscsi
 
 RULESDIR ?= $(etcdir)/udev/rules.d
 
+IQN_PREFIX ?= "iqn.2016-04.com.open-iscsi"
+
 CFLAGS ?= -O2 -fno-inline -g
 CFLAGS += -Wall -Wextra -Wstrict-prototypes
+CFLAGS += -DISCSI_NAME_PREFIX=\"$(IQN_PREFIX)\"
 
 PROGRAMS	= iscsi-iname
 PROGRAMS_DEST	= $(addprefix $(DESTDIR)$(SBINDIR)/,$(PROGRAMS))

--- a/utils/iscsi-iname.c
+++ b/utils/iscsi-iname.c
@@ -38,8 +38,6 @@
 
 #define RANDOM_NUM_GENERATOR	"/dev/urandom"
 
-#define DEFAULT_PREFIX		"iqn.2016-04.com.open-iscsi"
-
 /* iSCSI names have a maximum length of 223 characters, we reserve 13 to append
  * a seperator and 12 characters (6 random bytes in hex representation) */
 #define PREFIX_MAX_LEN 210
@@ -49,7 +47,7 @@ static void usage(void)
 	fprintf(stderr, "Usage: iscsi-iname [OPTIONS]\n");
 	fprintf(stderr, "Where OPTIONS are from:\n");
 	fprintf(stderr, "    -p/--prefix <prefix>          -- set IQN prefix [%s]\n",
-			DEFAULT_PREFIX);
+			ISCSI_NAME_PREFIX);
 	fprintf(stderr, "    -g/--generate-iname-prefix    -- generate the InitiatorName= prefix\n");
 	fprintf(stderr, "where <prefix> has max length of %d\n",
 		PREFIX_MAX_LEN);
@@ -67,7 +65,7 @@ main(int argc, char *argv[])
 	unsigned char entropy[16];
 	int e;
 	int fd;
-	char *prefix = DEFAULT_PREFIX;
+	char *prefix = ISCSI_NAME_PREFIX;
 	int c;
 	char *short_options = "p:gh";
 	struct option const long_options[] = {


### PR DESCRIPTION
In some cases open-isns may not be needed or may not be available. Make building without it optional, using meson. The depricated Makefile build is not effected.