### PR TITLE
iscsi-iname: make default IQN prefix configurable

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,18 +15,20 @@ etcdir = /etc
 DBROOT ?= $(etcdir)/iscsi
 HOMEDIR ?= $(etcdir)/iscsi
 
+IQN_PREFIX ?= "iqn.2016-04.com.open-iscsi"
+
 prefix ?= /usr
 mandir ?= $(prefix)/share/man
 
 MAN8DIR = $(DESTDIR)$(mandir)/man8
 
 MANPAGES_SOURCES	= iscsi_discovery.8 \
-			  iscsi_fw_login.8 \
-			  iscsi-iname.8
+			  iscsi_fw_login.8
 MANPAGES_TEMPLATES	= iscsid.8.template \
 			  iscsiadm.8.template \
 			  iscsi-gen-initiatorname.8 \
-			  iscsistart.8.template
+			  iscsistart.8.template \
+			  iscsi-iname.8.template
 MANPAGES_GENERATED	= $(MANPAGES_TEMPLATES:.template=)
 MANPAGES_DEST		= $(addprefix $(MAN8DIR)/,$(MANPAGES_GENERATED)) \
 			  $(addprefix $(MAN8DIR)/,$(MANPAGES_SOURCES))
@@ -38,7 +40,7 @@ install: install_doc
 install_doc: $(MAN8DIR) $(MANPAGES_DEST)
 
 $(MANPAGES_GENERATED): %.8: %.8.template
-	$(SED) -e 's:@HOMEDIR@:$(HOMEDIR):' -e 's:@DBROOT@:$(DBROOT):' $? > $@
+	$(SED) -e 's:@HOMEDIR@:$(HOMEDIR):' -e 's:@DBROOT@:$(DBROOT):' -e 's:@IQN_PREFIX@:$(IQN_PREFIX):' $? > $@
 
 $(MANPAGES_DEST): $(MAN8DIR)/%: %
 	$(INSTALL) -m 644 $? $@

--- a/doc/iscsi-iname.8.template
+++ b/doc/iscsi-iname.8.template
@@ -14,7 +14,7 @@ generates a unique iSCSI node name on every invocation.
 Display help
 .TP
 .BI [-p=]\fIprefix\fP
-Use the prefix passed in instead of the default "iqn.2016-04.com.open-iscsi"
+Use the prefix passed in instead of the default "@IQN_PREFIX@"
 
 .SH AUTHORS
 Open-iSCSI project <http://www.open-iscsi.com/>

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -3,15 +3,15 @@
 # static man pages
 iscsi_doc_man_pages_static = files([
   'iscsi_discovery.8',
-  'iscsi_fw_login.8',
-  'iscsi-iname.8'])
+  'iscsi_fw_login.8'])
 
 # template man pages
 iscsi_doc_man_pages_templates = [
   'iscsid',
   'iscsiadm',
   'iscsi-gen-initiatorname',
-  'iscsistart']
+  'iscsistart',
+  'iscsi-iname']
 iscsi_doc_man_pages_template_arr = {}
 foreach t: iscsi_doc_man_pages_templates
   iscsi_doc_man_pages_template_arr += {t + '.8': files(t + '.8.template')}

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ endif
 c_args = get_option('c_args')
 man_dir = get_option('mandir')
 iscsi_sbindir = get_option('iscsi_sbindir')
+iqn_prefix = get_option('iqn_prefix')
 
 #
 # get list of sources from subdirs (iscsiuio included at bottom)
@@ -56,6 +57,7 @@ conf = configuration_data()
 conf.set('SBINDIR', iscsi_sbindir)
 conf.set('HOMEDIR', home_dir)
 conf.set('DBROOT', db_root)
+conf.set('IQN_PREFIX', iqn_prefix)
 
 
 # set up general C args
@@ -65,7 +67,8 @@ genl_cargs = [
   '-DISCSI_CONFIG_ROOT="@0@"'.format(home_dir),
   '-DISCSI_DB_ROOT="@0@"'.format(db_root),
   '-DLOCK_DIR="@0@"'.format(lock_dir),
-  '-DISCSI_VERSION_STR="@0@"'.format(meson.project_version())]
+  '-DISCSI_VERSION_STR="@0@"'.format(meson.project_version()),
+  '-DISCSI_NAME_PREFIX="@0@"'.format(iqn_prefix)]
 
 # set up no-system flag, if needed
 if no_systemd

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,3 +21,7 @@ option('rulesdir', type: 'string', value: 'udev/rules.d',
 # older version of meson do not allow overriding sbindir
 option('iscsi_sbindir', type: 'string', value: '/usr/sbin',
   description: 'Set the directory where our binaries go [/usr/sbin]')
+
+# default iqn prefix use for iscsi-iname
+option('iqn_prefix', type: 'string', value: 'iqn.2016-04.com.open-iscsi',
+  description: 'Set the prefix used by iscsi-iname to generate iSCSI names')

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -18,8 +18,11 @@ HOMEDIR ?= $(etcdir)/iscsi
 
 RULESDIR ?= $(etcdir)/udev/rules.d
 
+IQN_PREFIX ?= "iqn.2016-04.com.open-iscsi"
+
 CFLAGS ?= -O2 -fno-inline -g
 CFLAGS += -Wall -Wextra -Wstrict-prototypes
+CFLAGS += -DISCSI_NAME_PREFIX=\"$(IQN_PREFIX)\"
 
 PROGRAMS	= iscsi-iname
 PROGRAMS_DEST	= $(addprefix $(DESTDIR)$(SBINDIR)/,$(PROGRAMS))

--- a/utils/iscsi-iname.c
+++ b/utils/iscsi-iname.c
@@ -38,8 +38,6 @@
 
 #define RANDOM_NUM_GENERATOR	"/dev/urandom"
 
-#define DEFAULT_PREFIX		"iqn.2016-04.com.open-iscsi"
-
 /* iSCSI names have a maximum length of 223 characters, we reserve 13 to append
  * a seperator and 12 characters (6 random bytes in hex representation) */
 #define PREFIX_MAX_LEN 210
@@ -49,7 +47,7 @@ static void usage(void)
 	fprintf(stderr, "Usage: iscsi-iname [OPTIONS]\n");
 	fprintf(stderr, "Where OPTIONS are from:\n");
 	fprintf(stderr, "    -p/--prefix <prefix>          -- set IQN prefix [%s]\n",
-			DEFAULT_PREFIX);
+			ISCSI_NAME_PREFIX);
 	fprintf(stderr, "    -g/--generate-iname-prefix    -- generate the InitiatorName= prefix\n");
 	fprintf(stderr, "where <prefix> has max length of %d\n",
 		PREFIX_MAX_LEN);
@@ -67,7 +65,7 @@ main(int argc, char *argv[])
 	unsigned char entropy[16];
 	int e;
 	int fd;
-	char *prefix = DEFAULT_PREFIX;
+	char *prefix = ISCSI_NAME_PREFIX;
 	int c;
 	char *short_options = "p:gh";
 	struct option const long_options[] = {


### PR DESCRIPTION
Packagers might want to change the default IQN prefix to use their own domain name information.  Provide a build time option for that.