### PR TITLE
Remove incorrect "BindTo" line in iscsiuio.service

### DIFF
--- a/etc/systemd/iscsiuio.service.template
+++ b/etc/systemd/iscsiuio.service.template
@@ -4,7 +4,6 @@ Documentation=man:iscsiuio(8)
 DefaultDependencies=no
 Conflicts=shutdown.target
 Requires=iscsid.service
-BindTo=iscsid.service
 After=network.target
 Before=remote-fs-pre.target iscsid.service
 Wants=remote-fs-pre.target


### PR DESCRIPTION
The correct syntax is "BindsTo", but we do not
actually want to use this, because it would imply
that iscsid.service needs to be started _before_
iscsiuio.service, but that is backwards.

Found by: Martin Wilck @ SUSE