### PR TITLE
iscsiuio build: use correct new version

### DIFF
--- a/iscsiuio/meson.build
+++ b/iscsiuio/meson.build
@@ -17,7 +17,7 @@ log_rotate_dir = get_option('sysconfdir') / 'logrotate.d'
 #
 # our VERSION
 #
-iscsiuio_version = '0.7.8.6'
+iscsiuio_version = '0.7.8.7'
 release_template = '-DPACKAGE_VERSION="@0@"'
 release_str = release_template.format(iscsiuio_version)
 


### PR DESCRIPTION
New version is 0.7.8.7, so update meson
to use that.