### PR TITLE
remove unicode symbol from iscsid.conf

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -69,7 +69,7 @@ node.leading_login = No
 # To configure which CHAP algorithms to enable, set
 # node.session.auth.chap_algs to a comma separated list.
 # The algorithms should be listed in order of decreasing
-# preference — in particular, with the most preferred algorithm first.
+# preference - in particular, with the most preferred algorithm first.
 # Valid values are MD5, SHA1, SHA256, and SHA3-256.
 # The default is MD5.
 #node.session.auth.chap_algs = SHA3-256,SHA256,SHA1,MD5


### PR DESCRIPTION
Trivial fixup.  I ran into a test script that failed becuase iscsid.conf wasn't ASCII.  I like UTF-8, but none of this code handles it. And while unicode bytes in a comment shouldn't be the end of the world, it's just a lot clearer to remove the single offending symbol.