### PR TITLE
usr/idbm.c: fix musl build

### DIFF
--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -45,6 +45,11 @@
 #include "fw_context.h"
 #include "iscsi_err.h"
 
+// GLOB_ONLYDIR is not defined under musl
+#ifndef GLOB_ONLYDIR
+#define GLOB_ONLYDIR	0x100
+#endif
+
 #define IDBM_HIDE	0    /* Hide parameter when print. */
 #define IDBM_SHOW	1    /* Show parameter when print. */
 #define IDBM_MASKED	2    /* Show "stars" instead of real value when print */


### PR DESCRIPTION
Fix the following musl build failure raised since version 2.1.9 and https://github.com/open-iscsi/open-iscsi/commit/7b571d76d6937a78c141630fc38c3c57c532466c:

```
../usr/idbm.c: In function 'idbm_rec_write_old':
../usr/idbm.c:2230:27: error: 'GLOB_ONLYDIR' undeclared (first use in this function)
 2230 |         rc = glob(portal, GLOB_ONLYDIR, NULL, &globbuf);
      |                           ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/14fc1c139f055b5b1eaa6e04e327863c06176a7b