### PR TITLE
iscsiuio: manage threads better at shutdown

### DIFF
--- a/iscsiuio/src/unix/libs/cnic.c
+++ b/iscsiuio/src/unix/libs/cnic.c
@@ -369,6 +369,7 @@ int cnic_handle_ipv4_iscsi_path_req(nic_t *nic, int fd,
 
 	rc = uip_lookup_arp_entry(dst_addr.s_addr, mac_addr);
 	if (rc != 0) {
+		event_loop_observer_add();
 		while ((arp_retry < MAX_ARP_RETRY) && (event_loop_stop == 0)) {
 			char *dst_addr_str;
 			int count;
@@ -425,6 +426,7 @@ int cnic_handle_ipv4_iscsi_path_req(nic_t *nic, int fd,
 
 			arp_retry++;
 		}
+		event_loop_observer_remove();
 	}
 
 done:
@@ -562,6 +564,7 @@ int cnic_handle_ipv6_iscsi_path_req(nic_t *nic, int fd,
 			  addr_dst_str, sizeof(addr_dst_str));
 		ILOG_DEBUG(PFX "%s: Preparing to send IPv6 neighbor solicitation to dst: '%s'",
 			   nic->log_name, addr_dst_str);
+		event_loop_observer_add();
 		while ((neighbor_retry < MAX_ARP_RETRY)
 		       && (event_loop_stop == 0)) {
 			int count;
@@ -621,6 +624,7 @@ int cnic_handle_ipv6_iscsi_path_req(nic_t *nic, int fd,
 			}
 			neighbor_retry++;
 		}
+		event_loop_observer_remove();
 	}
 
 done:

--- a/iscsiuio/src/unix/main.c
+++ b/iscsiuio/src/unix/main.c
@@ -199,22 +199,18 @@ signal_wait:
 	 * issues where they may not do so.
 	 */
 	waitcount = WAITCOUNT_MAX;
-	while (waitcount--) {
+	while ((event_loop_observers > 0) && waitcount--) {
 		sleep(1);
-		if (!event_loop_observers)
-			break;	/* success! */
-		if (event_loop_observers < 0) {
-			ILOG_INFO("Invalid observer count: %d",
-				  event_loop_observers);
-			break;
-		}
+		if (event_loop_observers <= 0)
+			break;	/* they finished while we were sleeping */
 		ILOG_INFO("%d threads still polling event_loop_stop flag after %d seconds",
 			  event_loop_observers, WAITCOUNT_MAX - waitcount);
 	}
-	if (event_loop_observers > 0)
+	if (event_loop_observers < 0)
+		ILOG_DEBUG("Invalid observer count: %d", event_loop_observers);
+	else if (event_loop_observers > 0)
 		ILOG_ERR("%d unresponsive observers will be cancelled: %d",
 			 event_loop_observers);
-
 	cleanup();
 	exit(EXIT_SUCCESS);
 }

--- a/iscsiuio/src/unix/nic.c
+++ b/iscsiuio/src/unix/nic.c
@@ -1199,6 +1199,7 @@ static int process_dhcp_loop(nic_t *nic,
 	periodic_timer->start = periodic_timer->start -
 	    periodic_timer->interval;
 
+	event_loop_observer_add();
 	while ((event_loop_stop == 0) &&
 	       (nic->flags & NIC_ENABLED) && !(nic->flags & NIC_GOING_DOWN)) {
 
@@ -1238,6 +1239,7 @@ static int process_dhcp_loop(nic_t *nic,
 			return -EIO;
 		}
 	}
+	event_loop_observer_remove();
 
 	if (nic->flags & NIC_GOING_DOWN)
 		return -EIO;
@@ -1393,6 +1395,7 @@ void *nic_loop(void *arg)
 	pthread_cond_signal(&nic->nic_loop_started_cond);
 
 	/* nic_mutex must be locked */
+	event_loop_observer_add();
 	while ((event_loop_stop == 0) &&
 	       !(nic->flags & NIC_EXIT_MAIN_LOOP) &&
 	       !(nic->flags & NIC_GOING_DOWN)) {
@@ -1542,5 +1545,6 @@ dev_close:
 
 	nic->thread = INVALID_THREAD;
 
+	event_loop_observer_remove();
 	pthread_exit(NULL);
 }

--- a/iscsiuio/src/unix/nic.h
+++ b/iscsiuio/src/unix/nic.h
@@ -70,6 +70,8 @@ extern pthread_mutex_t nic_list_mutex;
 extern struct nic *nic_list;
 
 extern void *nl_process_handle_thread(void *arg);
+extern void event_loop_observer_add(void);
+extern void event_loop_observer_remove(void);
 
 /*******************************************************************************
  *  Constants

--- a/iscsiuio/src/unix/nic_nl.c
+++ b/iscsiuio/src/unix/nic_nl.c
@@ -145,6 +145,7 @@ kwritev(int fd, enum iscsi_uevent_e type, struct iovec *iovp, int count)
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 
+	event_loop_observer_add();
 	do {
 		rc = sendmsg(fd, &msg, 0);
 		if (rc == -ENOMEM) {
@@ -156,6 +157,7 @@ kwritev(int fd, enum iscsi_uevent_e type, struct iovec *iovp, int count)
 			sleep(1);
 		}
 	} while ((rc < 0) && (event_loop_stop == 0));
+	event_loop_observer_remove();
 
 	return rc;
 }
@@ -477,6 +479,7 @@ void *nl_process_handle_thread(void *arg)
 	if (nic == NULL)
 		goto error;
 
+	event_loop_observer_add();
 	while (!event_loop_stop) {
 		char *data = NULL;
 
@@ -502,6 +505,7 @@ void *nl_process_handle_thread(void *arg)
 			free(data);
 		}
 	}
+	event_loop_observer_remove();
 error:
 	return NULL;
 }
@@ -570,6 +574,7 @@ int nic_nl_open()
 	src_addr.nl_pid = getpid();
 	src_addr.nl_groups = ISCSI_NL_GRP_UIP;
 
+	event_loop_observer_add();
 	while ((!event_loop_stop)) {
 		rc = bind(nl_sock,
 			  (struct sockaddr *)&src_addr, sizeof(src_addr));
@@ -698,5 +703,6 @@ int nic_nl_open()
 	rc = 0;
 
 error:
+	event_loop_observer_remove();
 	return rc;
 }

--- a/iscsiuio/src/unix/ping.c
+++ b/iscsiuio/src/unix/ping.c
@@ -458,6 +458,7 @@ put_pkt:
 
 	timer_set(&ping_timer, CLOCK_SECOND * 10);
 
+	event_loop_observer_add();
 	while ((event_loop_stop == 0) &&
 	       (nic->flags & NIC_ENABLED) && !(nic->flags & NIC_GOING_DOWN)) {
 
@@ -481,6 +482,7 @@ put_pkt:
 	}
 
 done:
+	event_loop_observer_remove();
 	return rc;
 }
 


### PR DESCRIPTION
This commit adds ability for iscsiuio to count
threads started, and to wait for them at shutdown, up to 10 seconds maximum. It also adds a few
messages during that shutdown time if threads are
slow to shut down.

Testing showed that 100 iterations of stop/start
of the iscsiuio service completed without error
with these changes.