### PR TITLE
iscsiuio: update version to 0.7.8.8

### DIFF
--- a/iscsiuio/README
+++ b/iscsiuio/README
@@ -1,6 +1,6 @@
 Iscsiuio Userspace Tool
-Version 0.7.8.7
-Jun 13, 2023
+Version 0.7.8.8
+Oct 25, 2023
 ------------------------------------------------------
 
 This tool is to be used in conjunction with the QLogic NetXtreme II Linux

--- a/iscsiuio/RELEASE.TXT
+++ b/iscsiuio/RELEASE.TXT
@@ -1,7 +1,7 @@
                               Release Notes
                         QLogic uIP Linux Driver
-                            Version 0.7.8.7
-                               06/13/2023
+                            Version 0.7.8.8
+                               10/25/2023
 
                           QLogic Corporation
                         26650 Aliso Viejo Pkwy,
@@ -10,6 +10,47 @@
                Copyright (c) 2004 - 2013 Broadcom Corporation
                    Copyright (c) 2014, QLogic Corporation
                            All rights reserved
+
+uIP v0.7.8.8 (Oct 25, 2023)
+=======================================================
+    Fixes:
+    -------
+      1. Problem: iscsiuio can hang sometimes, at
+		  startup, or at shutdown, due to
+		  threads owning a mutex then going
+		  away. If this happens at shutdown,
+		  then the daemon may not start up
+		  correctly next time.
+	 Change: 1. Use syslog() for thread-safe
+		    logging instead of trying to roll
+		    our own. This required changing
+		    all of the internal LOG macros, so
+		    they did not clash with syslog. Also
+		    remomved were the unused logging
+		    statistics. Also, outout is no
+		    longer sent to both stdout and the
+		    log file for debug mode. All logging
+		    goes to stdout/stderr if in foreground,
+		    else all goes to syslog().
+		 2. Added the ability to track the
+		    number of "event loops" (i.e.
+		    threads doing work), so that at
+		    shutdown we can wait for all of
+		    them (maximum 10 seconds) to finish.
+		 3. The netlink socket is has SO_LINGER
+		    turned off when shutting down, just
+		    in case this helps if we immediately
+		    try to restart the daemon (and it
+		    can't hurt).
+		 4. The netlink soocket thread, which used
+		    to wait on a recvmsg(), now sets a one
+		    second timeout when reading from the
+		    socket. In this way, the thread can
+		    detect a shutdown request in, at most,
+		    one second (it used to hang).
+      2. Problem: iscsiuio consistently mispelled "associated"
+		 1. Fix the spelling in comments and in some
+		    function names.
 
 uIP v0.7.8.7 (Jun 13, 2023)
 =======================================================

--- a/iscsiuio/configure.ac
+++ b/iscsiuio/configure.ac
@@ -12,9 +12,9 @@ dnl             Benjamin Li  (benli@broadcom.com)
 dnl
 
 PACKAGE=iscsiuio
-VERSION=0.7.8.7
+VERSION=0.7.8.8
 
-AC_INIT([iscsiuio], [0.7.8.7], [QLogic-Storage-Upstream@marvell.com])
+AC_INIT([iscsiuio], [0.7.8.8], [QLogic-Storage-Upstream@marvell.com])
 
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADER(config.h)

--- a/iscsiuio/meson.build
+++ b/iscsiuio/meson.build
@@ -17,7 +17,7 @@ log_rotate_dir = get_option('sysconfdir') / 'logrotate.d'
 #
 # our VERSION
 #
-iscsiuio_version = '0.7.8.7'
+iscsiuio_version = '0.7.8.8'
 release_template = '-DPACKAGE_VERSION="@0@"'
 release_str = release_template.format(iscsiuio_version)
 

--- a/iscsiuio/src/unix/iscsid_ipc.c
+++ b/iscsiuio/src/unix/iscsid_ipc.c
@@ -124,7 +124,7 @@ static void *enable_nic_thread(void *data)
 
 	prepare_nic_thread(nic);
 	ILOG_INFO(PFX "%s: started NIC enable thread state: 0x%x",
-		 nic->log_name, nic->state)
+		 nic->log_name, nic->state);
 
 	/*  Enable the NIC */
 	nic_enable(nic);

--- a/iscsiuio/src/unix/logger.h
+++ b/iscsiuio/src/unix/logger.h
@@ -65,35 +65,39 @@
 #define LOG_LEVEL_UNKNOWN_STR	"?    "
 
 /*******************************************************************************
- * Logging Macro's
+ * Logging Macros
  ******************************************************************************/
-#define ILOG_PACKET(fmt, args...) { if (LOG_LEVEL_PACKET <= \
-				       main_log.level) { \
-					log_uip(LOG_INFO,\
-						LOG_LEVEL_PACKET_STR fmt,\
-						##args);\
-				} }
-#define ILOG_DEBUG(fmt, args...) { if (LOG_LEVEL_DEBUG <= main_log.level) { \
-					log_uip(LOG_DEBUG,\
-						LOG_LEVEL_DEBUG_STR fmt,\
-						##args);\
-				} }
 
-#define ILOG_INFO(fmt, args...)  { if (LOG_LEVEL_INFO <= main_log.level) { \
-					log_uip(LOG_INFO,\
-						LOG_LEVEL_INFO_STR fmt,\
-						##args); \
-				} }
-#define ILOG_WARN(fmt, args...)  { if (LOG_LEVEL_WARN <= main_log.level) { \
-					log_uip(LOG_NOTICE,\
-						LOG_LEVEL_WARN_STR fmt,\
-						##args); \
-				} }
-#define ILOG_ERR(fmt, args...)   { if (LOG_LEVEL_ERR <= main_log.level) { \
-					log_uip(LOG_ERR,\
-						LOG_LEVEL_ERR_STR fmt,\
-						##args); \
-				} }
+#define ILOG_PACKET(fmt, args...) \
+	do {if (LOG_LEVEL_PACKET <= main_log.level) {\
+		log_uip(LOG_INFO,\
+			LOG_LEVEL_PACKET_STR fmt,\
+			##args);\
+	} } while (0)
+#define ILOG_DEBUG(fmt, args...) \
+	do {if (LOG_LEVEL_DEBUG <= main_log.level) {\
+		log_uip(LOG_DEBUG,\
+			LOG_LEVEL_DEBUG_STR fmt,\
+			##args);\
+	} } while (0)
+#define ILOG_INFO(fmt, args...) \
+	do {if (LOG_LEVEL_INFO <= main_log.level) {\
+		log_uip(LOG_INFO,\
+			LOG_LEVEL_INFO_STR fmt,\
+			##args);\
+	} } while (0)
+#define ILOG_WARN(fmt, args...) \
+	do {if (LOG_LEVEL_WARN <= main_log.level) {\
+		log_uip(LOG_NOTICE,\
+			LOG_LEVEL_WARN_STR fmt,\
+			##args);\
+	} } while (0)
+#define ILOG_ERR(fmt, args...) \
+	do {if (LOG_LEVEL_ERR <= main_log.level) {\
+		log_uip(LOG_ERR,\
+			LOG_LEVEL_ERR_STR fmt,\
+			##args);\
+	} } while (0)
 
 /*******************************************************************************
  * Logger Structure


### PR DESCRIPTION
Fixes an issue where iscsiuio would not compile because of the way the logging macros worked. Also, updated iscsiuio version after fixing the logging issue.