### PR TITLE
Incorrect documentation for `iscsiadm -m session` print level

### DIFF
--- a/README
+++ b/README
@@ -486,7 +486,8 @@ Mode "session"
 			  but in session mode targetname and portal info
 			  is not passed in.
 
-			  Print level can be 0 to 2.
+			  Print level can be 0 to 3.
+			  0 = Print the running sessions.
 			  1 = Print basic session info like node we are
 			  connected to and whether we are connected.
 			  2 = Print iSCSI params used.


### PR DESCRIPTION
The documentation states that the print level can be between 0 and 2, but then lists the levels as 1 to 3.
Is 

Excerpt provided below for context:
```
Print level can be 0 to 2.
			  1 = Print basic session info like node we are
			  connected to and whether we are connected.
			  2 = Print iSCSI params used.
			  3 = Print SCSI info like LUNs, device state.
```

I've updated the range of values to include 3, and provided a description for print level 0.