### PR TITLE
Stop using deprecated inet_aton and inet_ntoa

### DIFF
--- a/iscsiuio/src/uip/uip_arp.c
+++ b/iscsiuio/src/uip/uip_arp.c
@@ -453,15 +453,15 @@ int uip_lookup_arp_entry(uint32_t ip_addr, uint8_t *mac_addr)
 		if (((entry->ipaddr[1] << 16) == (ip_addr & 0xffff0000)) &&
 		    ((entry->ipaddr[0]) == (ip_addr & 0x0000ffff))) {
 			struct in_addr addr;
-			char *addr_str;
+			char addr_buf[INET_ADDRSTRLEN];
 
 			addr.s_addr = ip_addr;
-			addr_str = inet_ntoa(addr);
+			inet_ntop(AF_INET, &addr, addr_buf, sizeof(addr_buf));
 
 			memcpy(mac_addr, entry->ethaddr.addr, 6);
 
 			ILOG_INFO("Found %s at %02x:%02x:%02x:%02x:%02x:%02x",
-				 addr_str,
+				 addr_buf,
 				 mac_addr[0], mac_addr[1], mac_addr[2],
 				 mac_addr[3], mac_addr[4], mac_addr[5]);
 			rc = 0;

--- a/iscsiuio/src/unix/nic.c
+++ b/iscsiuio/src/unix/nic.c
@@ -1255,7 +1255,8 @@ static int do_acquisition(nic_t *nic, nic_interface_t *nic_iface,
 {
 	struct in_addr addr;
 	struct in6_addr addr6;
-	char buf[INET6_ADDRSTRLEN];
+	char buf_ipv6[INET6_ADDRSTRLEN];
+	char buf_ipv4[INET_ADDRSTRLEN];
 	int rc = -1;
 
 	/* New acquisition */
@@ -1280,13 +1281,15 @@ static int do_acquisition(nic_t *nic, nic_interface_t *nic_iface,
 		       sizeof(addr.s_addr));
 
 		ILOG_INFO(PFX "%s: Using IP address: %s",
-			 nic->log_name, inet_ntoa(addr));
+			 nic->log_name,
+			 inet_ntop(AF_INET, &addr, buf_ipv4, sizeof(buf_ipv4)));
 
 		memcpy(&addr.s_addr, nic_iface->ustack.netmask,
 		       sizeof(addr.s_addr));
 
 		ILOG_INFO(PFX "%s: Using netmask: %s",
-			 nic->log_name, inet_ntoa(addr));
+			 nic->log_name,
+			 inet_ntop(AF_INET, &addr, buf_ipv4, sizeof(buf_ipv4)));
 
 		set_uip_stack(&nic_iface->ustack,
 			      NULL, NULL, NULL,
@@ -1349,12 +1352,12 @@ static int do_acquisition(nic_t *nic, nic_interface_t *nic_iface,
 		if (nic_iface->ustack.ip_config == IPV6_CONFIG_STATIC) {
 			memcpy(&addr6.s6_addr, nic_iface->ustack.hostaddr6,
 			       sizeof(addr6.s6_addr));
-			inet_ntop(AF_INET6, addr6.s6_addr, buf, sizeof(buf));
-			ILOG_INFO(PFX "%s: hostaddr IP: %s", nic->log_name, buf);
+			inet_ntop(AF_INET6, addr6.s6_addr, buf_ipv6, sizeof(buf_ipv6));
+			ILOG_INFO(PFX "%s: hostaddr IP: %s", nic->log_name, buf_ipv6);
 			memcpy(&addr6.s6_addr, nic_iface->ustack.netmask6,
 			       sizeof(addr6.s6_addr));
-			inet_ntop(AF_INET6, addr6.s6_addr, buf, sizeof(buf));
-			ILOG_INFO(PFX "%s: netmask IP: %s", nic->log_name, buf);
+			inet_ntop(AF_INET6, addr6.s6_addr, buf_ipv6, sizeof(buf_ipv6));
+			ILOG_INFO(PFX "%s: netmask IP: %s", nic->log_name, buf_ipv6);
 		}
 		break;
 

--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -290,21 +290,21 @@ int net_setup_netdev(char *netdev, char *local_ip, char *mask, char *gateway,
 	/* Bring up NIC with correct address  - unless it
 	 * has already been handled (2 targets in IBFT may share one NIC)
 	 */
-	if (!inet_aton(local_ip, &sk_ipaddr.sin_addr)) {
+	if (!inet_pton(AF_INET, local_ip, &sk_ipaddr.sin_addr)) {
 		log_error("Invalid or missing ipaddr in fw entry");
 		ret = EINVAL;
 		goto done;
 	}
 
-	if (!inet_aton(mask, &sk_netmask.sin_addr)) {
+	if (!inet_pton(AF_INET, mask, &sk_netmask.sin_addr)) {
 		log_error("Invalid or missing netmask in fw entry");
 		ret = EINVAL;
 		goto done;
 	}
 
-	inet_aton("255.255.255.255", &sk_hostmask.sin_addr);
+	inet_pton(AF_INET, "255.255.255.255", &sk_hostmask.sin_addr);
 
-	if (!inet_aton(remote_ip, &sk_tgt_ipaddr.sin_addr)) {
+	if (!inet_pton(AF_INET, remote_ip, &sk_tgt_ipaddr.sin_addr)) {
 		log_error("Invalid or missing target ipaddr in fw entry");
 		ret = EINVAL;
 		goto done;
@@ -381,7 +381,7 @@ int net_setup_netdev(char *netdev, char *local_ip, char *mask, char *gateway,
 	} else {
 		/* Different subnet.  Use gateway */
 		rt.rt_flags |= RTF_GATEWAY;
-		if (!inet_aton(gateway, &sk_gateway.sin_addr)) {
+		if (!inet_pton(AF_INET, gateway, &sk_gateway.sin_addr)) {
 			log_error("Invalid or missing gateway for %s "
 				  "(err %d - %s)",
 				  netdev, errno, strerror(errno));


### PR DESCRIPTION
The use of inet_aton is in usr/icsi_net_util.c, and the use of inet_ntoa is in iscsiuio/src/...
Use the modern versions, inet_pton and inet_ntop,
which support IPv6, are used instead, but they
require a buffer. See open-iscsi issue #433.