### PR TITLE
Fix setpriority issue

### DIFF
--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -22,7 +22,6 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/resource.h>
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
This fixes an issue in session_increase_wq_priority(). This function is called when setting up a session and host to increase the workqueue priority. The workqueue is named (by the kernel) "iscsi_q_HOSTNO", where HOSTNO is the host number. It previously did this by scanning /proc/PROCNO/stat files, but that was error prone and cumbersome/slow.  It used the "setpriority()" call on the process ID for the worker thread to do this, if it could find the process entry.

Instead, write to the "nice" value for the workqueue in sysfs, which is simpler, faster, and more reliable.