### PR TITLE
Fix authmethod check by printing a warning message when CHAP used and authmethod=None

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -64,6 +64,13 @@ node.leading_login = No
 
 # To enable CHAP authentication set node.session.auth.authmethod
 # to CHAP. The default is None.
+#
+# NOTE: currently this attribute is checked for validity but then
+# ignored, so even if it is set to None, CHAP will be used if the
+# credentials (username/password and possibly username_in/password_in)
+# are set. This behavior is deprecated, and in the future CHAP will
+# not be used if authmethod is set to None.
+#
 #node.session.auth.authmethod = CHAP
 
 # To configure which CHAP algorithms to enable, set
@@ -86,6 +93,9 @@ node.leading_login = No
 
 # To enable CHAP authentication for a discovery session to the target,
 # set discovery.sendtargets.auth.authmethod to CHAP. The default is None.
+#
+# See NOTE above for node.session.auth.authmethod being mostly ignored.
+#
 #discovery.sendtargets.auth.authmethod = CHAP
 
 # To set a discovery session CHAP username and password for the initiator

--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -167,6 +167,12 @@ extern int idbm_rec_update_param(recinfo_t *info, char *name, char *value,
 				 int line_number);
 extern void idbm_recinfo_node(node_rec_t *r, recinfo_t *ri);
 
+/* from libopeniscsiusr/idbm.h */
+enum iscsi_auth_method {
+	ISCSI_AUTH_METHOD_NONE,
+	ISCSI_AUTH_METHOD_CHAP,
+};
+
 enum {
 	IDBM_PRINT_TYPE_DISCOVERY,
 	IDBM_PRINT_TYPE_NODE,

--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -395,7 +395,18 @@ __session_create(node_rec_t *rec, struct iscsi_transport *t, int *rc)
 	session->isid[5] = 0;
 
 	/* setup authentication variables for the session*/
-	iscsi_setup_authentication(session, &rec->session.auth);
+	if (iscsi_setup_authentication(session, &rec->session.auth)) {
+		/*
+		 * FIXME: The return value used to be ignored here. It
+		 * would be nice to start paying attention to it, but
+		 * that may break a few corner-case login scenarios,
+		 * and in the case of a root-iSCSI setup, may break it
+		 * badly. So, for now, just print a warning that
+		 * ignoring such errors is being deprecated.
+		 */
+		log_warning("Warning: DEPRECATED: Ignoring Authorization setup failure. "
+			    "This will be considered a login error in the future.");
+	}
 
 	iscsi_session_init_params(session);
 

--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -399,22 +399,22 @@ __session_create(node_rec_t *rec, struct iscsi_transport *t, int *rc)
 
 	iscsi_session_init_params(session);
 
-        if (t->template->bind_ep_required) {
-                hostno = iscsi_sysfs_get_host_no_from_hwinfo(&rec->iface, rc);
-                if (!*rc) {
-                        /*
-                         * if the netdev or mac was set, then we are going to want
-                         * to want to bind the all the conns/eps to a specific host
-                         * if offload is used.
-                         */
-                        session->conn[0].bind_ep = 1;
-                        session->hostno = hostno;
-                } else if (*rc == ISCSI_ERR_HOST_NOT_FOUND) {
-                        goto free_session;	
-                } else {
-                         *rc = 0;
-                }
-        }
+	if (t->template->bind_ep_required) {
+		hostno = iscsi_sysfs_get_host_no_from_hwinfo(&rec->iface, rc);
+		if (!*rc) {
+			/*
+			 * if the netdev or mac was set, then we are going to want
+			 * to want to bind the all the conns/eps to a specific host
+			 * if offload is used.
+			 */
+			session->conn[0].bind_ep = 1;
+			session->hostno = hostno;
+		} else if (*rc == ISCSI_ERR_HOST_NOT_FOUND) {
+			goto free_session;
+		} else {
+			 *rc = 0;
+		}
+	}
 
 	/* reset session reopen count */
 	session->reopen_cnt = 0;

--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -405,7 +405,7 @@ __session_create(node_rec_t *rec, struct iscsi_transport *t, int *rc)
 		 * ignoring such errors is being deprecated.
 		 */
 		log_warning("Warning: DEPRECATED: Ignoring Authorization setup failure. "
-			    "This will be considered a login error in the future.");
+			    "This will be considered a login authorization error in the future.");
 	}
 
 	iscsi_session_init_params(session);

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -38,6 +38,7 @@
 #include "sysdeps.h"
 #include "iscsi_err.h"
 #include "iscsi_net_util.h"
+#include "idbm.h"
 
 struct iscsi_session *session_find_by_sid(uint32_t sid)
 {
@@ -61,6 +62,16 @@ static unsigned int align_32_down(unsigned int param)
 int iscsi_setup_authentication(struct iscsi_session *session,
 			       struct iscsi_auth_config *auth_cfg)
 {
+	/*
+	 * check for authmethod being set correctly,
+	 * and for now just warn user this isn't correct. In the
+	 * future, we should return an error here.
+	 */
+	if ((auth_cfg->authmethod == ISCSI_AUTH_METHOD_NONE) &&
+	    (auth_cfg->password_length || auth_cfg->password_in_length))
+		log_warning("Warning: DEPRECATED: Using CHAP even though 'authmethod' is set to None. "
+			    "In the future 'authmethod=None' will be honored.");
+
 	/* if we have any incoming credentials, we insist on authenticating
 	 * the target or not logging in at all
 	 */

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -68,9 +68,15 @@ int iscsi_setup_authentication(struct iscsi_session *session,
 	 * future, we should return an error here.
 	 */
 	if ((auth_cfg->authmethod == ISCSI_AUTH_METHOD_NONE) &&
-	    (auth_cfg->password_length || auth_cfg->password_in_length))
+	    (auth_cfg->password_length || auth_cfg->password_in_length)) {
+		/*
+		 * FIXME: if authmethod=None we should really not be using
+		 * CHAP, but fixing this may break some configurations, so
+		 * just warn the user, for now
+		 */
 		log_warning("Warning: DEPRECATED: Using CHAP even though 'authmethod' is set to None. "
 			    "In the future 'authmethod=None' will be honored.");
+	}
 
 	/* if we have any incoming credentials, we insist on authenticating
 	 * the target or not logging in at all


### PR DESCRIPTION
This doesn't add any functional changes, but it does add warning messages when authmethod=None and CHAP credentials are configured and used. It also adds a warning when an existing authorization failure occurs, but continues to ignore it (for now).

The documentation on authmethod in iscsid.conf is updated as well.