### PR TITLE
iscsid: Rescan devices on relogin

### DIFF
--- a/usr/iscsi_sysfs.h
+++ b/usr/iscsi_sysfs.h
@@ -17,6 +17,7 @@
 #ifndef ISCSI_SYSFS_H
 #define ISCSI_SYSFS_H
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 #include "sysfs.h"
@@ -89,7 +90,7 @@ extern void iscsi_sysfs_get_negotiated_session_conf(int sid,
 				struct iscsi_session_operational_config *conf);
 extern void iscsi_sysfs_get_negotiated_conn_conf(int sid,
 				struct iscsi_conn_operational_config *conf);
-extern pid_t iscsi_sysfs_scan_host(int hostno, int async, int autoscan);
+extern pid_t iscsi_sysfs_scan_host(int hostno, int sid, int async, bool rescan);
 extern int iscsi_sysfs_get_session_state(char *state, int sid);
 extern int iscsi_sysfs_get_host_state(char *state, int host_no);
 extern int iscsi_sysfs_get_device_state(char *state, int host_no, int target,

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -874,7 +874,7 @@ static int rescan_portal(void *data, struct session_info *info)
 	iscsi_sysfs_for_each_device(NULL, host_no, info->sid,
 				    iscsi_sysfs_rescan_device);
 	/* now scan for new devices */
-	iscsi_sysfs_scan_host(host_no, 0, 1);
+	iscsi_sysfs_scan_host(host_no, info->sid, 0, false);
 	return 0;
 }
 

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -221,7 +221,9 @@ static int sync_session(__attribute__((unused))void *data,
 				  iscsi_err_to_str(err));
 			return 0;
 		}
-		iscsi_sysfs_scan_host(host_no, 0, idbm_session_autoscan(NULL));
+
+		if (idbm_session_autoscan(NULL))
+			iscsi_sysfs_scan_host(host_no, info->sid, 0, false);
 		return 0;
 	}
 


### PR DESCRIPTION
If a device goes to offline/transport-offline when we are disconnected the device's size can be set to zero if some other app forces it to get rescanned. Normally in the kernel when a device is set from offline to running again, it will rescan the device. However, because during a relogin the iscsi layer sets the state from offline/transport-offline via iscsi_unblock_session we don't hit that rescan. We actually don't want to hit the kernel's rescan right now, because it can block and that would block all iscsid operations.

This has us perform a rescan operation after a relogin from the scan process.