### PR TITLE
Modify how workqueue priority is set

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -214,8 +214,21 @@ node.session.queue_depth = 32
 # Note: For cxgb3i, you must set all sessions to the same value.
 # Otherwise the behavior is not defined.
 #
-# The default value is -20. The setting must be between -20 and 20.
-node.session.xmit_thread_priority = -20
+# This is done by scanning /proc/PID/stat, and this doesn't work in
+# newer kernels (6.* on), as the workqueue transmit thread can be
+# passive, and not show in in the process table when not actively
+# doing work. If the proper workqueue process is found, and the
+# priority value is non-zero, then the priority of that process will
+# be modified when a session is created.
+#
+# Note: as mentioned above, the default value is now zero, which means
+# that we don't do anything to the transmit workqueue process priority,
+# by default. If you wish to get the previous behavior, set this value
+# to -20. In the future, this functionality will be removed, once this
+# functionality is no longer needed or works.
+#
+# The default value is 0. The setting must be between -20 and 20.
+# node.session.xmit_thread_priority = 0
 
 
 #***************

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -3231,7 +3231,7 @@ void idbm_node_setup_defaults(node_rec_t *rec)
 	rec->disc_type = DISCOVERY_TYPE_STATIC;
 	rec->leading_login = 0;
 	rec->session.cmds_max = CMDS_MAX;
-	rec->session.xmit_thread_priority = XMIT_THREAD_PRIORITY;
+	rec->session.xmit_thread_priority = DEFAULT_XMIT_THREAD_PRIORITY;
 	rec->session.initial_cmdsn = 0;
 	rec->session.queue_depth = QUEUE_DEPTH;
 	rec->session.nr_sessions = 1;

--- a/usr/iscsi_settings.h
+++ b/usr/iscsi_settings.h
@@ -21,8 +21,8 @@
 #define CMDS_MAX	128
 #define QUEUE_DEPTH	32
 
-/* system */
-#define XMIT_THREAD_PRIORITY	-20
+/* system -- default used for setpriority() of the xmit workqueue process */
+#define DEFAULT_XMIT_THREAD_PRIORITY	0
 
 /* interface */
 #define UNKNOWN_VALUE		"<empty>"


### PR DESCRIPTION
The open-iscsi code has been scanning the process table when it creates a new session (and hence a new host), in order to raise the priority of the workqueue transmit thread, to avoid a possible priority inversion with kernel threads like bdflush.

In modern kernels the workqueue transmit thread can be passive, meaning that it will not show up in the process table unless it is actively doing work. This means that we can no longer count on scanning the process table. But the good news is that those modern workqueue threads are designed differently and will not get deadlocked at their normal priority.

For now, we just optimize the code so that if the requested priority is zero, we do nothing, and we change the default value to zero, as well.

In the future the process-table-scanning code should be removed.