### PR TITLE
iscsiadm: allow hostnames in node-mode commands

### DIFF
--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -279,7 +279,7 @@ char *cfg_get_string_param(char *pathname, const char *key)
  *
  * If address1 is blank then it matches any string passed in.
  */
-static int iscsi_addr_match(char *address1, char *address2)
+int iscsi_addr_match(char *address1, char *address2)
 {
 	struct addrinfo hints1, hints2, *res1, *res2;
 	int rc;

--- a/usr/iscsi_util.h
+++ b/usr/iscsi_util.h
@@ -30,4 +30,6 @@ extern char *cfg_get_string_param(char *pathname, const char *key);
 struct sockaddr_un;
 extern int setup_abstract_addr(struct sockaddr_un *addr, char *unix_sock_name);
 
+extern int iscsi_addr_match(char *address1, char *address2);
+
 #endif


### PR DESCRIPTION
Commit 4d045cdeaf70 ('iscsi tools: support hostnames in node mode') was supposed to allow hostnames when using iscsiadm in node mode, but it was still comparing the connection address from the node entry with the "-p" hostname passed in, so the test would fail when running something like this:

> # iscsiadm -m discovery -t st -p HOSTNAME
> ...
> # iscsiadm -m node -p HOSTNAME -l

because we were comparing an IP address and a hostname. Instead, use the existing iscsi_addr_match() function created by the commit listed above to compare the HOSTNAME.