### PR TITLE
Better handle multiple iscsiadm commands

### DIFF
--- a/libopeniscsiusr/idbm.h
+++ b/libopeniscsiusr/idbm.h
@@ -40,6 +40,12 @@
 #define BOOT_NAME_MAXLEN	256
 #define IDBM_DUMP_SIZE		8192
 
+/*
+ * wait up to DB_LOCK_USECS_WAIT * DB_LOCK_RETRIES to a cquire
+ * the DB lock, before giving up
+ */
+#define DB_LOCK_USECS_WAIT		10000	/* per-loop waiting for lock */
+#define	DB_LOCK_RETRIES			3000	/* number of retries */
 
 struct __DLL_LOCAL idbm;
 

--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -51,6 +51,14 @@
 #define NAME_MAXVAL	128   /* the maximum length of key name */
 #define VALUE_MAXVAL	256   /* the maximum length of 223 bytes in the RFC. */
 #define OPTS_MAXVAL	8
+
+/*
+ * wait up to DB_LOCK_USECS_WAIT * DB_LOCK_RETRIES to a cquire
+ * the DB lock, before giving up
+ */
+#define DB_LOCK_USECS_WAIT		10000	/* per-loop waiting for lock */
+#define	DB_LOCK_RETRIES			3000	/* number of retries */
+
 typedef struct recinfo {
 	int		type;
 	char		name[NAME_MAXVAL];


### PR DESCRIPTION
The DB locking was racing, at times, since it did something like:

    if (access() != 0)
	    if (mkdir() != 0)
		    error

But when multiple processes are running, it is possible for a process to have access() fail, but then mkdir also fail, since another process has created the directory between the check and the attempt at creation. (Note that this error only seemed to occur on first use of iscsiadm, during testing.)

This change essentially makes EEXIST of the directory ok, with some other cleanups of the locking code (in two places).