### PR TITLE
systemd: Skip units when running in container

### DIFF
--- a/etc/systemd/iscsi-init.service.template
+++ b/etc/systemd/iscsi-init.service.template
@@ -7,6 +7,7 @@ RequiresMountsFor=/etc/iscsi
 # local-fs.target, don't start it here (no Wants=) but if
 # it's running wait for it to finish
 After=systemd-remount-fs.service
+ConditionVirtualization=!container
 
 [Install]
 # this ensures we are in the same transaction with

--- a/etc/systemd/iscsi.service.template
+++ b/etc/systemd/iscsi.service.template
@@ -5,6 +5,7 @@ Before=remote-fs.target
 After=network-online.target iscsid.service
 Requires=iscsid.socket iscsi-init.service
 Wants=network-online.target
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/etc/systemd/iscsid.service.template
+++ b/etc/systemd/iscsid.service.template
@@ -6,6 +6,7 @@ After=network-online.target iscsiuio.service iscsi-init.service
 Before=remote-fs-pre.target
 Wants=remote-fs-pre.target
 Requires=iscsi-init.service
+ConditionVirtualization=!container
 
 [Service]
 Type=notify

--- a/etc/systemd/iscsid.socket
+++ b/etc/systemd/iscsid.socket
@@ -1,6 +1,7 @@
 [Unit]
 Description=Open-iSCSI iscsid Socket
 Documentation=man:iscsid(8) man:iscsiadm(8)
+ConditionVirtualization=!container
 
 [Socket]
 ListenStream=@ISCSIADM_ABSTRACT_NAMESPACE

--- a/etc/systemd/iscsiuio.service.template
+++ b/etc/systemd/iscsiuio.service.template
@@ -7,6 +7,7 @@ Requires=iscsid.service
 After=network.target
 Before=remote-fs-pre.target iscsid.service
 Wants=remote-fs-pre.target
+ConditionVirtualization=!container
 
 [Service]
 Type=notify

--- a/etc/systemd/iscsiuio.socket
+++ b/etc/systemd/iscsiuio.socket
@@ -1,6 +1,7 @@
 [Unit]
 Description=Open-iSCSI iscsiuio Socket
 Documentation=man:iscsiuio(8)
+ConditionVirtualization=!container
 
 [Socket]
 ListenStream=@ISCSID_UIP_ABSTRACT_NAMESPACE


### PR DESCRIPTION
iscsi might be installed in an image that can be booted both as a container and as a virtual machine (or bare metal). Let's condition out the units when running in a container as iscsi can't reliably do its job in a container anyways.

Without this commit, iscsi may fail to start when booting an image with iscsi installed in a systemd-nspawn container.