### PR TITLE
Make it visible when memory allocation failure

### DIFF
--- a/usr/idbm.h
+++ b/usr/idbm.h
@@ -189,7 +189,7 @@ enum {
 	IDBM_PRINT_TYPE_FLASHNODE
 };
 
-extern void idbm_print(int type, void *rec, int show, FILE *f);
+extern int idbm_print(int type, void *rec, int show, FILE *f);
 
 struct boot_context;
 extern struct node_rec *idbm_create_rec(char *targetname, int tpgt,

--- a/usr/iface.c
+++ b/usr/iface.c
@@ -282,7 +282,7 @@ int iface_conf_write(struct iface_rec *iface)
 	if (rc)
 		goto close_f;
 
-	idbm_print(IDBM_PRINT_TYPE_IFACE, iface, 1, f);
+	rc = idbm_print(IDBM_PRINT_TYPE_IFACE, iface, 1, f);
 	idbm_unlock();
 
 close_f:


### PR DESCRIPTION
During the node discovery process, if there's a memory allocation failure occured in idbm_print(), an empty node DB file will be created silently.