### PR TITLE
Bugfix read specific sysfs value "off" of session attribute

### DIFF
--- a/libopeniscsiusr/sysfs.c
+++ b/libopeniscsiusr/sysfs.c
@@ -285,14 +285,18 @@ static int iscsi_sysfs_prop_get_ll(struct iscsi_context *ctx,
 		}
 	}
 
-	errno = 0;
-	tmp_val = strtoll((const char *) buff, NULL, 10 /* base */);
-	errno_save = errno;
-	if ((errno_save != 0) && (! ignore_error)) {
-		rc = LIBISCSI_ERR_BUG;
-		_error(ctx, "Sysfs: %s: Error when converting '%s' "
-		       "to number", file_path,  (char *) buff, errno_save);
-		goto out;
+	if (strncmp((const char *) buff, "off", 3) == 0) {
+		tmp_val = -1;
+	} else {
+		errno = 0;
+		tmp_val = strtoll((const char *) buff, NULL, 10 /* base */);
+		errno_save = errno;
+		if ((errno_save != 0) && (! ignore_error)) {
+			rc = LIBISCSI_ERR_BUG;
+			_error(ctx, "Sysfs: %s: Error when converting '%s' "
+			       "to number", file_path,  (char *) buff, errno_save);
+			goto out;
+		}
 	}
 
 	*val = tmp_val;

--- a/usr/sysfs.c
+++ b/usr/sysfs.c
@@ -563,7 +563,12 @@ int sysfs_get_int(const char *id, char *subsys, char *param, int *value)
 	if (!sysfs_value)
 		return EIO;
 
-	*value = atoi(sysfs_value);
+	if (strncmp(sysfs_value, "off", 3) == 0 &&
+            strncmp(subsys, "iscsi_session", 13) == 0) {
+                *value = -1;
+        } else {
+                *value = atoi(sysfs_value);
+        }
 	free(sysfs_value);
 	return 0;
 }


### PR DESCRIPTION
Linux kernel convert session_attr int value "off" to -1 in scsi_transport_iscsi  module. 
![image](https://github.com/user-attachments/assets/f6fa1ed6-20d6-43e2-b852-875aa5ac6af8)

But open-iscsi don't convert special value "off" to -1. It will mistake session attibute info display.  
example: If set recovery_tmo "off"(`echo off > /sys/class/iscsi_session/session808/recovery_tmo`), this means  recovery_tmo=-1.  But (`iscsiadm -m session -P 3`) will mistake output "Recovery Timeout: 0".
![image](https://github.com/user-attachments/assets/55753cd7-f0c0-43d9-9106-74fe121af2fe)

