### PR TITLE
Fix bug where abort_tmo read failures were ignored.

### DIFF
--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -1342,7 +1342,7 @@ int iscsi_sysfs_get_sessioninfo_by_id(struct session_info *info, char *session)
 	if (ret)
 		(info->tmo).lu_reset_tmo = -1;
 
-	sysfs_get_int(session, ISCSI_SESSION_SUBSYS, "abort_tmo",
+	ret = sysfs_get_int(session, ISCSI_SESSION_SUBSYS, "abort_tmo",
 				&((info->tmo).abort_tmo));
 	if (ret)
 		(info->tmo).abort_tmo = -1;


### PR DESCRIPTION
The code was using the return value from reading tgt_reset_tmo to decide if it should use the abort_tmo value.