### PR TITLE
iface.h:include<sys/uio.h>,fix clang build error

### DIFF
--- a/usr/iface.h
+++ b/usr/iface.h
@@ -21,6 +21,7 @@
 #define ISCSI_IFACE_H
 
 #include <libopeniscsiusr/libopeniscsiusr.h>
+#include <sys/uio.h>
 
 #define IFACE_CONFIG_DIR	ISCSI_DB_ROOT"/ifaces"
 


### PR DESCRIPTION
Hi!this fix Issue #469 
`struct iovec`is defined in <sys/uio.h>

Please fix the bug!Thanks!