### PR TITLE
fixed clang build error: attribute declaration must precede definition

### DIFF
--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -32,6 +32,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include "iface.h"
 #include "local_strings.h"
 #include "types.h"
 #include "iscsi_proto.h"
@@ -46,7 +47,6 @@
 #include "transport.h"
 #include "iscsi_sysfs.h"
 #include "iscsi_ipc.h"
-#include "iface.h"
 #include "iscsi_timer.h"
 #include "iscsi_err.h"
 #if ISNS_SUPPORTED

--- a/usr/discoveryd.c
+++ b/usr/discoveryd.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "iface.h"
 #include "discovery.h"
 #include "idbm.h"
 #include "list.h"
@@ -37,7 +38,6 @@
 #include "session_mgmt.h"
 #include "iscsi_util.h"
 #include "event_poll.h"
-#include "iface.h"
 #include "session_mgmt.h"
 #include "session_info.h"
 #include "iscsi_err.h"

--- a/usr/host.c
+++ b/usr/host.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <errno.h>
 
+#include "iface.h"
 #include "list.h"
 #include "iscsi_util.h"
 #include "log.h"
@@ -32,7 +33,6 @@
 #include "session_info.h"
 #include "transport.h"
 #include "initiator.h"
-#include "iface.h"
 #include "iscsi_err.h"
 #include "iscsi_netlink.h"
 

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -33,6 +33,7 @@
 #include <sys/file.h>
 #include <inttypes.h>
 
+#include "iface.h"
 #include "idbm.h"
 #include "idbm_fields.h"
 #include "log.h"
@@ -40,7 +41,6 @@
 #include "iscsi_settings.h"
 #include "transport.h"
 #include "iscsi_sysfs.h"
-#include "iface.h"
 #include "sysdeps.h"
 #include "fw_context.h"
 #include "iscsi_err.h"

--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -31,6 +31,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 
+#include "iface.h"
 #include "initiator.h"
 #include "transport.h"
 #include "iscsid.h"
@@ -44,7 +45,6 @@
 #include "scsi.h"
 #include "iscsi_sysfs.h"
 #include "iscsi_settings.h"
-#include "iface.h"
 #include "host.h"
 #include "sysdeps.h"
 #include "iscsi_err.h"

--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <libmount/libmount.h>
 
+#include "iface.h"
 #include "initiator.h"
 #include "transport.h"
 #include "iscsid.h"
@@ -33,7 +34,6 @@
 #include "log.h"
 #include "iscsi_sysfs.h"
 #include "iscsi_settings.h"
-#include "iface.h"
 #include "host.h"
 #include "sysdeps.h"
 #include "iscsi_err.h"

--- a/usr/io.c
+++ b/usr/io.c
@@ -30,6 +30,7 @@
 #include <arpa/inet.h>
 #include <sys/uio.h>
 
+#include "iface.h"
 #include "types.h"
 #include "iscsi_proto.h"
 #include "iscsi_settings.h"
@@ -38,7 +39,6 @@
 #include "log.h"
 #include "transport.h"
 #include "idbm.h"
-#include "iface.h"
 #include "sysdeps.h"
 
 #define LOG_CONN_CLOSED(conn) \

--- a/usr/iscsi_sysfs.c
+++ b/usr/iscsi_sysfs.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#include "iface.h"
 #include "log.h"
 #include "initiator.h"
 #include "transport.h"
@@ -35,7 +36,6 @@
 #include "iscsi_sysfs.h"
 #include "sysdeps.h"
 #include "iscsi_settings.h"
-#include "iface.h"
 #include "session_info.h"
 #include "host.h"
 #include "iscsi_err.h"

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -38,6 +38,7 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+#include "iface.h"
 #include "iscsid.h"
 #include "mgmt_ipc.h"
 #include "event_poll.h"
@@ -49,7 +50,6 @@
 #include "idbm.h"
 #include "version.h"
 #include "iscsi_sysfs.h"
-#include "iface.h"
 #include "session_info.h"
 #include "sysdeps.h"
 #include "discoveryd.h"

--- a/usr/iscsistart.c
+++ b/usr/iscsistart.c
@@ -33,6 +33,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "iface.h"
 #include "initiator.h"
 #include "iscsi_ipc.h"
 #include "event_poll.h"
@@ -45,11 +46,9 @@
 #include "iscsi_sysfs.h"
 #include "iscsi_settings.h"
 #include "fw_context.h"
-#include "iface.h"
 #include "sysdeps.h"
 #include "iscsid_req.h"
 #include "iscsi_err.h"
-#include "iface.h"
 
 /* global config info */
 /* initiator needs initiator name/alias */

--- a/usr/mntcheck.c
+++ b/usr/mntcheck.c
@@ -24,6 +24,7 @@
 #include <dirent.h>
 #include <libmount/libmount.h>
 
+#include "iface.h"
 #include "initiator.h"
 #include "transport.h"
 #include "iscsid.h"
@@ -31,7 +32,6 @@
 #include "log.h"
 #include "iscsi_sysfs.h"
 #include "iscsi_settings.h"
-#include "iface.h"
 #include "host.h"
 #include "sysdeps.h"
 #include "iscsi_err.h"

--- a/usr/session_mgmt.c
+++ b/usr/session_mgmt.c
@@ -24,11 +24,11 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include "session_info.h"
 #include "idbm.h"
 #include "list.h"
 #include "iscsi_util.h"
 #include "mgmt_ipc.h"
-#include "session_info.h"
 #include "iscsi_sysfs.h"
 #include "log.h"
 #include "iscsid_req.h"


### PR DESCRIPTION
this fixed issue #471 