### PR TITLE
iscsid: Fix hang during login with scan=manual

### DIFF
--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -1023,8 +1023,10 @@ static void session_scan_host(struct iscsi_session *session, int hostno,
 {
 	pid_t pid;
 
-	if (!rescan && !idbm_session_autoscan(session))
+	if (!rescan && !idbm_session_autoscan(session)) {
+		mgmt_ipc_write_rsp(qtask, ISCSI_SUCCESS);
 		return;
+	}
 
 	pid = iscsi_sysfs_scan_host(hostno, session->id, 1, rescan);
 	if (pid == 0) {


### PR DESCRIPTION
This fixes a regression added in:

48e683c ('iscsid: Rescan devices on relogin (#444)

 For scan=manual we were not sending a response to callers like iscsiadm so they would hang.

See issue:

https://github.com/open-iscsi/open-iscsi/issues/484