### PR TITLE
IPv6 support for iBFT iSCSI boot

### DIFF
--- a/include/iscsi_net_util.h
+++ b/include/iscsi_net_util.h
@@ -11,9 +11,13 @@
 
 extern int net_get_transport_name_from_netdev(char *netdev, char *transport);
 extern int net_get_netdev_from_hwaddress(char *hwaddress, char *netdev);
-extern int net_setup_netdev(char *netdev, char *local_ip, char *mask,
-			    char *gateway, char *vlan, char *remote_ip,
-			    int needs_bringup);
+extern int net_get_ip_version(char *ip);
+extern int net_setup_netdev_ipv4(char *netdev, char *local_ip, char *mask,
+				 char *gateway, char *vlan, char *remote_ip,
+				 int needs_bringup);
+extern int net_setup_netdev_ipv6(char *netdev, char *local_ip, int prefix,
+				 char *gateway, char *vlan, char *remote_ip,
+				 int needs_bringup);
 extern int net_ifup_netdev(char *netdev);
 
 #endif

--- a/usr/fwparam_ibft/fw_entry.c
+++ b/usr/fwparam_ibft/fw_entry.c
@@ -73,12 +73,22 @@ int fw_setup_nics(void)
 				needs_bringup = 1;
 		}
 		if (net_get_transport_name_from_netdev(context->iface, transport)) {
+			int ip_ver = net_get_ip_version(context->ipaddr);
+
 			/* Setup software NIC, */
 			printf("Setting up software interface %s\n", context->iface);
-			err = net_setup_netdev(context->iface, context->ipaddr,
-								   context->mask, context->gateway,
-								   context->vlan,
-								   context->target_ipaddr, needs_bringup);
+			if (ip_ver == AF_INET)
+				err = net_setup_netdev_ipv4(context->iface, context->ipaddr,
+						context->mask, context->gateway,
+						context->vlan, context->target_ipaddr,
+						needs_bringup);
+			else if (ip_ver == AF_INET6)
+				err = net_setup_netdev_ipv6(context->iface, context->ipaddr,
+						context->prefix, context->gateway,
+						context->vlan, context->target_ipaddr,
+						needs_bringup);
+			else
+				err = ip_ver;
 			if (err) {
 				printf("Setting up software interface %s failed\n",
 						context->iface);


### PR DESCRIPTION
Use IPv4-specific APIs during NIC setup based on iBFT information, regardless of the IP version, which leads to the following error in IPv6-only environments:

Setting up software interface ens300f0np0
iscsistart: Invalid or missing ipaddr in fw entry
Setting up software interface ens300f0np0 failed

To address this, the process now determines the IP version first and calls the appropriate functions to handle NIC setup.