### PR TITLE
Modify log function to print session id

### DIFF
--- a/etc/iscsid.conf
+++ b/etc/iscsid.conf
@@ -357,7 +357,7 @@ node.session.reopen_max = 0
 # rediscover the iscsi targets. If the value for this config value is 4,
 # then these session reopen logs will be logged for every 12 seconds
 # (4 * 3 seconds = 12 seconds). Values below 1 are treated as 1 (default).
-# node.session.conn_reopen_log_freq = 1
+# node.session.sess_reopen_log_freq = 1
 
 #************
 # Workarounds

--- a/libopeniscsiusr/default.c
+++ b/libopeniscsiusr/default.c
@@ -77,7 +77,7 @@ void _default_node(struct iscsi_node *node)
 	node->session.nr_sessions = 1;
 	node->session.initial_login_retry_max = DEF_INITIAL_LOGIN_RETRIES_MAX;
 	node->session.reopen_max = DEF_SESSION_REOPEN_MAX;
-	node->session.conn_reopen_log_freq = DEF_CONN_REOPEN_LOG_FREQ;
+	node->session.sess_reopen_log_freq = DEF_SESSION_REOPEN_LOG_FREQ;
 	node->session.auth.authmethod = 0;
 	/* TYPE_INT_LIST fields should be initialized to ~0 to indicate unset values */
 	memset(node->session.auth.chap_algs, ~0, sizeof(node->session.auth.chap_algs));

--- a/libopeniscsiusr/default.h
+++ b/libopeniscsiusr/default.h
@@ -58,7 +58,7 @@
 #define	DEF_SESSION_REOPEN_MAX		0
 
 /* session reopen log frequency i.e number of reopens per message */
-#define DEF_CONN_REOPEN_LOG_FREQ    1
+#define DEF_SESSION_REOPEN_LOG_FREQ    1
 
 /* default window size */
 #define TCP_WINDOW_SIZE			(512 * 1024)

--- a/libopeniscsiusr/idbm.c
+++ b/libopeniscsiusr/idbm.c
@@ -1111,7 +1111,7 @@ static void _idbm_node_rec_link(struct iscsi_node *node, struct idbm_rec *recs, 
 		    "auto", num, _CAN_MODIFY);
 	_rec_int64(SESSION_REOPEN_MAX, recs, node, session.reopen_max, IDBM_SHOW, num,
 		   _CAN_MODIFY);
-	_rec_int64(CONN_REOPEN_LOG_FREQ, recs, node, session.conn_reopen_log_freq, IDBM_SHOW, num,
+	_rec_int64(SESSION_REOPEN_LOG_FREQ, recs, node, session.sess_reopen_log_freq, IDBM_SHOW, num,
 		   _CAN_MODIFY);
 
 	_rec_str(CONN_ADDR, recs, node, conn.address, IDBM_SHOW, num,

--- a/libopeniscsiusr/idbm.h
+++ b/libopeniscsiusr/idbm.h
@@ -220,7 +220,7 @@ struct iscsi_session_idbm {
 	char					boot_root[BOOT_NAME_MAXLEN];
 	char					boot_nic[BOOT_NAME_MAXLEN];
 	char					boot_target[BOOT_NAME_MAXLEN];
-	int64_t                                 conn_reopen_log_freq;
+	int64_t                                 sess_reopen_log_freq;
 
 };
 

--- a/libopeniscsiusr/idbm_fields.h
+++ b/libopeniscsiusr/idbm_fields.h
@@ -138,7 +138,7 @@
 #define SESSION_ERL		"node.session.iscsi.ERL"
 #define SESSION_SCAN		"node.session.scan"
 #define SESSION_REOPEN_MAX	"node.session.reopen_max"
-#define CONN_REOPEN_LOG_FREQ 	"node.session.conn_reopen_log_freq"
+#define SESSION_REOPEN_LOG_FREQ "node.session.sess_reopen_log_freq"
 
 /* connections fields */
 #define CONN_ADDR		"node.conn[0].address"

--- a/usr/actor.c
+++ b/usr/actor.c
@@ -67,7 +67,7 @@ actor_delete(actor_t *thread)
 		/* priority: low */
 		/* fallthrough */
 	case ACTOR_SCHEDULED:
-		log_debug(1, "deleting a scheduled/waiting thread %p:%s!",
+		log_debug(4, "deleting a scheduled/waiting thread %p:%s!",
 			 thread, thread->name);
 		list_del_init(&thread->list);
 		if (list_empty(&pend_list)) {

--- a/usr/auth.c
+++ b/usr/auth.c
@@ -156,7 +156,7 @@ acl_chap_auth_request(struct iscsi_acl *client, char *username, unsigned int id,
 	auth_hash_final(verify_data, context);
 
 	if (memcmp(response_data, verify_data, sizeof(verify_data)) == 0) {
-		conn_log_connect(1,session,  "initiator authenticated target %s",
+		sess_log_connect(1,session,  "initiator authenticated target %s",
 			  session->target_name);
 		return AUTH_STATUS_PASS;
 	}

--- a/usr/config.h
+++ b/usr/config.h
@@ -199,7 +199,7 @@ typedef struct session_rec {
 	char					boot_root[BOOT_NAME_MAXLEN];
 	char					boot_nic[BOOT_NAME_MAXLEN];
 	char					boot_target[BOOT_NAME_MAXLEN];
-	int                                     conn_reopen_log_freq;
+	int                                     sess_reopen_log_freq;
 } session_rec_t;
 
 #define ISCSI_TRANSPORT_NAME_MAXLEN 16

--- a/usr/discovery.c
+++ b/usr/discovery.c
@@ -823,7 +823,7 @@ iscsi_alloc_session(struct iscsi_sendtargets_config *config,
 	session->conn[0].noop_out_timeout = 0;
 	session->conn[0].noop_out_interval = 0;
 	session->reopen_cnt = config->reopen_max + 1;
-	session->conn_reopen_log_freq = DEF_CONN_REOPEN_LOG_FREQ;
+	session->sess_reopen_log_freq = DEF_SESSION_REOPEN_LOG_FREQ;
 	iscsi_copy_operational_params(&session->conn[0], &config->session_conf,
 				      &config->conn_conf);
 

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -526,8 +526,8 @@ idbm_recinfo_node(node_rec_t *r, recinfo_t *ri)
 			 num, 1);
 	__recinfo_int(SESSION_REOPEN_MAX, ri, r,
 			session.reopen_max, IDBM_SHOW, num, 1);
-	__recinfo_int(CONN_REOPEN_LOG_FREQ, ri, r,
-			session.conn_reopen_log_freq, IDBM_SHOW, num, 1);
+	__recinfo_int(SESSION_REOPEN_LOG_FREQ, ri, r,
+			session.sess_reopen_log_freq, IDBM_SHOW, num, 1);
 
 	for (i = 0; i < ISCSI_CONN_MAX; i++) {
 		char key[NAME_MAXVAL];
@@ -3288,7 +3288,7 @@ void idbm_node_setup_defaults(node_rec_t *rec)
 	rec->session.nr_sessions = 1;
 	rec->session.initial_login_retry_max = DEF_INITIAL_LOGIN_RETRIES_MAX;
 	rec->session.reopen_max = DEF_SESSION_REOPEN_MAX;
-	rec->session.conn_reopen_log_freq = DEF_CONN_REOPEN_LOG_FREQ;
+	rec->session.sess_reopen_log_freq = DEF_SESSION_REOPEN_LOG_FREQ;
 	rec->session.auth.authmethod = 0;
 	/* TYPE_INT_LIST fields should be initialized to ~0 to indicate unset values */
 	memset(rec->session.auth.chap_algs, ~0, sizeof(rec->session.auth.chap_algs));

--- a/usr/idbm_fields.h
+++ b/usr/idbm_fields.h
@@ -48,7 +48,7 @@
 #define SESSION_ERL		"node.session.iscsi.ERL"
 #define SESSION_SCAN		"node.session.scan"
 #define SESSION_REOPEN_MAX	"node.session.reopen_max"
-#define CONN_REOPEN_LOG_FREQ 	"node.session.conn_reopen_log_freq"
+#define SESSION_REOPEN_LOG_FREQ "node.session.sess_reopen_log_freq"
 
 /* connections fields */
 #define CONN_ADDR		"node.conn[%d].address"

--- a/usr/initiator.h
+++ b/usr/initiator.h
@@ -295,7 +295,7 @@ typedef struct iscsi_session {
 	/* connection reopens during recovery */
 	int reopen_cnt;
 	int reopen_max;
-	int conn_reopen_log_freq;
+	int sess_reopen_log_freq;
 	queue_task_t reopen_qtask;
 	iscsi_session_r_stage_e r_stage;
 	uint32_t replacement_timeout;

--- a/usr/io.c
+++ b/usr/io.c
@@ -322,7 +322,7 @@ iscsi_io_tcp_connect(iscsi_conn_t *conn, int non_blocking)
 		    conn->host, sizeof(conn->host), serv, sizeof(serv),
 		    NI_NUMERICHOST|NI_NUMERICSERV);
 
-	conn_log_connect(1, conn->session, "connecting to %s:%s", conn->host, serv);
+	sess_log_connect(1, conn->session, "connecting to %s:%s", conn->host, serv);
 	if (non_blocking)
 		set_non_blocking(conn->socket_fd);
 	rc = connect(conn->socket_fd, (struct sockaddr *) ss, sizeof (*ss));
@@ -367,8 +367,8 @@ iscsi_io_tcp_poll(iscsi_conn_t *conn, int timeout_ms)
 			    conn->host, sizeof(conn->host), serv, sizeof(serv),
 			    NI_NUMERICHOST|NI_NUMERICSERV);
 
-		if (conn->session->conn_reopen_log_freq > 1)
-			conn_log_connect(1, conn->session, "connect to %s:%s failed (%s)",
+		if (conn->session->sess_reopen_log_freq > 1)
+			sess_log_connect(1, conn->session, "connect to %s:%s failed (%s)",
 					       conn->host, serv, strerror(rc));
 		else
 			log_error("connect to %s:%s failed (%s)",
@@ -387,7 +387,7 @@ iscsi_io_tcp_poll(iscsi_conn_t *conn, int timeout_ms)
 		getnameinfo((struct sockaddr *) &ss, sizeof(ss),
 			     NULL, 0, lserv, sizeof(lserv), NI_NUMERICSERV);
 
-		conn_log_connect(1, conn->session, "connected local port %s to %s:%s",
+		sess_log_connect(1, conn->session, "connected local port %s to %s:%s",
 			  lserv, conn->host, serv);
 	}
 	return 1;
@@ -399,7 +399,7 @@ iscsi_io_tcp_disconnect(iscsi_conn_t *conn)
 	struct linger so_linger = { .l_onoff = 1, .l_linger = 0 };
 
 	if (conn->socket_fd >= 0) {
-		conn_log_connect(1, conn->session, "disconnecting conn %p, fd %d", conn,
+		sess_log_connect(1, conn->session, "disconnecting conn %p, fd %d", conn,
 			 conn->socket_fd);
 
 		/* If the state is not IN_LOGOUT, this isn't a clean shutdown

--- a/usr/iscsi_settings.h
+++ b/usr/iscsi_settings.h
@@ -18,7 +18,7 @@
 #define	DEF_SESSION_REOPEN_MAX	0
 
 /* session reopen log frequency i.e number of reopens per message */
-#define DEF_CONN_REOPEN_LOG_FREQ 1
+#define DEF_SESSION_REOPEN_LOG_FREQ 1
 
 /* q depths */
 #define CMDS_MAX	128

--- a/usr/iscsi_util.c
+++ b/usr/iscsi_util.c
@@ -304,7 +304,7 @@ int iscsi_addr_match(const char *address1, const char *address2)
 	 */
 	rc = getaddrinfo(address1, NULL, &hints1, &res1);
 	if (rc) {
-		conn_log_connect(1, NULL, "Match error. Could not resolve %s: %s", address1,
+		sess_log_connect(1, NULL, "Match error. Could not resolve %s: %s", address1,
 			  gai_strerror(rc));
 		return 0;
 
@@ -312,7 +312,7 @@ int iscsi_addr_match(const char *address1, const char *address2)
 
 	rc = getaddrinfo(address2, NULL, &hints2, &res2);
 	if (rc) {
-		conn_log_connect(1, NULL, "Match error. Could not resolve %s: %s", address2,
+		sess_log_connect(1, NULL, "Match error. Could not resolve %s: %s", address2,
 			  gai_strerror(rc));
 		rc = 0;
 		goto free_res1;

--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -471,7 +471,7 @@ __do_leading_login(void *data, struct list_head *list, struct node_rec *rec)
 	struct iface_rec *pattern_iface = data;
 	int nr_found;
 
-	conn_log_connect(1, NULL, "doing leading login using iface: %s", pattern_iface->name);
+	sess_log_connect(1, NULL, "doing leading login using iface: %s", pattern_iface->name);
 
 	/* Skip any records that do not match the pattern iface */
 	if (!iface_match(pattern_iface, &rec->iface))
@@ -482,7 +482,7 @@ __do_leading_login(void *data, struct list_head *list, struct node_rec *rec)
 	 * the leading login is complete.
 	 */
 	if (iscsi_sysfs_for_each_session(rec, &nr_found, iscsi_match_target, 0)) {
-		conn_log_connect(1, NULL, "Skipping %s: Already a session for that target",
+		sess_log_connect(1, NULL, "Skipping %s: Already a session for that target",
 			  rec->name);
 		return -1;
 	}
@@ -531,7 +531,7 @@ login_by_startup(char *mode, bool wait)
 	rc = err;
 
 	if (!list_empty(&startup.all_logins)) {
-		conn_log_connect(1, NULL, "Logging into normal (non-leading-login) portals");
+		sess_log_connect(1, NULL, "Logging into normal (non-leading-login) portals");
 		/* Login all regular (non-leading-login) portals first */
 		err = iscsi_login_portals(NULL, &nr_found, wait,
 				&startup.all_logins, iscsi_login_portal);
@@ -550,11 +550,11 @@ login_by_startup(char *mode, bool wait)
 		struct node_rec *rec, *tmp_rec;
 		LIST_HEAD(iface_list);
 		int missed_leading_login = 0;
-		conn_log_connect(1, NULL, "Logging into leading-login portals");
+		sess_log_connect(1, NULL, "Logging into leading-login portals");
 		iface_link_ifaces(&iface_list);
 		list_for_each_entry_safe(pattern_iface, tmp_iface, &iface_list,
 					 list) {
-			conn_log_connect(1, NULL, "Establishing leading-logins via iface %s",
+			sess_log_connect(1, NULL, "Establishing leading-logins via iface %s",
 				  pattern_iface->name);
 			err = iscsi_login_portals_safe(pattern_iface, &nr_found,
 						       1,
@@ -2862,7 +2862,7 @@ static int exec_node_op(struct iscsi_context *ctx, int op, int do_login,
 	int rc = 0;
 
 	if (rec)
-		conn_log_connect(2, NULL, "%s: %s:%s node [%s,%s,%d] sid %u", __FUNCTION__,
+		sess_log_connect(2, NULL, "%s: %s:%s node [%s,%s,%d] sid %u", __FUNCTION__,
 			  rec->iface.transport_name, rec->iface.name,
 			  rec->name, rec->conn[0].address, rec->conn[0].port,
 			  rec->session.sid);

--- a/usr/iscsid.c
+++ b/usr/iscsid.c
@@ -287,7 +287,7 @@ retry:
 		sleep(1);
 		goto retry;
 	} else if (rc == ISCSI_ERR_SESS_EXISTS) {
-		conn_log_connect(1, NULL, "sync session %d returned ISCSI_ERR_SESS_EXISTS", info->sid);
+		sess_log_connect(1, NULL, "sync session %d returned ISCSI_ERR_SESS_EXISTS", info->sid);
 	}
 
 	return 0;

--- a/usr/log.c
+++ b/usr/log.c
@@ -337,24 +337,31 @@ void log_info(const char *fmt, ...)
 	va_end(ap);
 }
 
-void conn_log_connect(int level, iscsi_session_t *session, const char *fmt, ...)
+void sess_log_connect(int level, iscsi_session_t *session, const char *fmt, ...)
 {
 	int reopen_cnt = 0;
-	int conn_reopen_log_freq = DEF_CONN_REOPEN_LOG_FREQ;
+	int sess_reopen_log_freq = DEF_SESSION_REOPEN_LOG_FREQ;
+	char message_str[MAX_MSG_SIZE];
 
+	memset(message_str, 0, MAX_MSG_SIZE);
 	if (session) {
 		reopen_cnt = session->reopen_cnt;
-		conn_reopen_log_freq = session->conn_reopen_log_freq;
-		if (conn_reopen_log_freq < 1)
-			conn_reopen_log_freq = DEF_CONN_REOPEN_LOG_FREQ;
+		sess_reopen_log_freq = session->sess_reopen_log_freq;
+		if (sess_reopen_log_freq < 1)
+			sess_reopen_log_freq = DEF_SESSION_REOPEN_LOG_FREQ;
+		if (session->id > 0)
+			sprintf(message_str, "session%d ", session->id);
+		strcat(message_str, fmt);
 	}
+	else
+		strcpy(message_str, fmt);
 
 	if ((log_level >= level) &&
 		((log_level > 2) ||
-		 (reopen_cnt % conn_reopen_log_freq == 0))) {
+		 (reopen_cnt % sess_reopen_log_freq == 0))) {
 		va_list ap;
 		va_start(ap, fmt);
-		log_func(LOG_DEBUG, log_func_priv, fmt, ap);
+		log_func(LOG_DEBUG, log_func_priv, message_str, ap);
 		va_end(ap);
 	}
 

--- a/usr/log.h
+++ b/usr/log.h
@@ -80,7 +80,7 @@ extern void log_error(const char *fmt, ...)
 	__attribute__ ((format (printf, 1, 2)));
 extern void log_debug(int level, const char *fmt, ...)
 	__attribute__ ((format (printf, 2, 3)));
-extern void conn_log_connect(int level, struct iscsi_session *, const char *fmt, ...)
+extern void sess_log_connect(int level, struct iscsi_session *, const char *fmt, ...)
 	__attribute__ ((format (printf, 3, 4)));
 
 extern void log_do_log_daemon(int prio, void *priv, const char *fmt, va_list ap);

--- a/usr/login.c
+++ b/usr/login.c
@@ -283,7 +283,7 @@ get_security_text_keys(iscsi_session_t *session, int cid, char **data,
 		tag = strtoul(value, NULL, 0);
 		if (session->portal_group_tag >= 0) {
 			if (tag != session->portal_group_tag)
-				conn_log_connect(2, session, "Portal group tag "
+				sess_log_connect(2, session, "Portal group tag "
 					  "mismatch, expected %u, "
 					  "received %u. Updating",
 					  session->portal_group_tag, tag);
@@ -356,7 +356,7 @@ get_op_params_text_keys(iscsi_session_t *session, int cid,
 		 */
 		if (session->portal_group_tag >= 0) {
 			if (tag != session->portal_group_tag)
-				conn_log_connect(2, session, "Portal group tag "
+				sess_log_connect(2, session, "Portal group tag "
 					  "mismatch, expected %u, "
 					  "received %u. Updating",
 					  session->portal_group_tag, tag);
@@ -1487,7 +1487,7 @@ iscsi_login_rsp(iscsi_session_t *session, iscsi_login_context_t *c)
 	 */
 	c->status_class = c->login_rsp->status_class;
 	c->status_detail = c->login_rsp->status_detail;
-	conn_log_connect(1, session, "login response status %02d%02d",
+	sess_log_connect(1, session, "login response status %02d%02d",
 			c->status_class, c->status_detail);
 	c->ret = check_status_login_response(session, c->cid,
 		     c->login_rsp, c->data, c->max_data_length,

--- a/usr/session_mgmt.c
+++ b/usr/session_mgmt.c
@@ -110,7 +110,7 @@ __iscsi_login_portal(void *data, struct list_head *list, struct node_rec *rec)
 		rec->session.multiple = pattern_rec->session.multiple;
 	}
 
-	conn_log_connect(1, NULL, "Logging in to [iface: %s, target: %s, portal: %s,%d]%s",
+	sess_log_connect(1, NULL, "Logging in to [iface: %s, target: %s, portal: %s,%d]%s",
 		 rec->iface.name, rec->name, rec->conn[0].address,
 		 rec->conn[0].port,
 		 (rec->session.multiple ? " (multiple)" : ""));
@@ -118,7 +118,7 @@ __iscsi_login_portal(void *data, struct list_head *list, struct node_rec *rec)
 	if (list) {
 		async_req = calloc(1, sizeof(*async_req));
 		if (!async_req)
-			conn_log_connect(1, NULL, "Could not allocate memory for async login "
+			sess_log_connect(1, NULL, "Could not allocate memory for async login "
 				 "handling. Using sequential login instead.");
 		else
 			INIT_LIST_HEAD(&async_req->list);
@@ -195,7 +195,7 @@ int iscsi_login_portal(void *data, struct list_head *list, struct node_rec *rec)
 	if (rec->session.nr_sessions > 1)
 		rec->session.multiple = 1;
 	for (i = session_count; i < rec->session.nr_sessions; ++i) {
-		conn_log_connect(1, NULL, "%s: Creating session %d/%d", rec->iface.name,
+		sess_log_connect(1, NULL, "%s: Creating session %d/%d", rec->iface.name,
 			  i + 1, rec->session.nr_sessions);
 		int err = __iscsi_login_portal(pattern_rec, list, rec);
 		if (err && !rc)


### PR DESCRIPTION
This pull request if for following patches:
1. Modify log function to print session id
2. Change the log_level of log_debug message in actor_delete()