### PR TITLE
Fix minor typo ("authenticaton")

### DIFF
--- a/usr/auth.c
+++ b/usr/auth.c
@@ -2095,7 +2095,7 @@ acl_dbg_status_to_text(int dbg_status)
 		"CHAP response bad",
 		"Unexpected key present",
 		"T bit set on response, but not on previous message",
-		"T bit set on response, but authenticaton not complete",
+		"T bit set on response, but authentication not complete",
 		"Message count limit reached on receive",
 		"Same key set more than once on receive",
 		"Key value too long on receive",


### PR DESCRIPTION
I'm not sure how this typo has lasted 21 years, but I'm pleased to have found it!

I'm happy to rebase/amend/adjust/give up/etc as desired. :rocket:

Thanks for maintaining Open-iSCSI :heart: