### PR TITLE
doc: fixup iscsiadm man page option for -r

### DIFF
--- a/doc/iscsiadm.8.template
+++ b/doc/iscsiadm.8.template
@@ -434,7 +434,7 @@ use of the word node, does not match the iSCSI RFC's iSCSI Node term.
 .TP
 \fB\-r\fR, \fB\-\-sid=\fIsid | sysfsdir\fR
 Use session ID \fIsid\fR. The session ID of a session can be found from running
-iscsiadm in session mode with the \fI\-\-info\fR argument.
+iscsiadm in session mode.
 .IP
 Instead of a session ID, a sysfs path containing the session can be used.
 For example using one of the following:


### PR DESCRIPTION
As per mane page, we could use "--info" option however that gives an error. Hence slight modifications might be needed to "-r" option.

```
$ man iscsiadm | grep -A1 -B2 '--info'
       -r, --sid=sid | sysfsdir
              Use  session  ID sid. The session ID of a session can be found from running iscsiadm in session
              mode with the --info argument.
 $ iscsiadm -m session --info
iscsiadm: unrecognized option '--info'
iscsiadm: session mode: option '-?' is not allowed/supported
```

-----------------
We could fetch the desired details without "--info" or by using "show" or "info" option 
```
# iscsiadm -m session -P 3 |grep SID
        SID: 7
root@localhost:~# iscsiadm -m session info
tcp: [7] 10.76.241.0:3260,1 iqn.2025-03.com.example:server1 (non-flash)
root@localhost:~# iscsiadm -m session
tcp: [7] 10.76.241.0:3260,1 iqn.2025-03.com.example:server1 (non-flash)
# iscsiadm -m session show
tcp: [7] 10.76.241.0:3260,1 iqn.2025-03.com.example:server1 (non-flash)
```
