### PR TITLE
fwparam_ppc.c: Fix the calloc-transposed-args issue

### DIFF
--- a/usr/fwparam_ibft/fwparam_ppc.c
+++ b/usr/fwparam_ibft/fwparam_ppc.c
@@ -346,7 +346,7 @@ static int find_initiator(const char *fpath,
 				      "/aliases/iscsi-disk"))) {
 
 		if (dev_count < OFWDEV_MAX) {
-			dev = calloc(sizeof(struct ofw_dev), 1);
+			dev = calloc(1, sizeof(struct ofw_dev));
 			if (!dev)
 				return -ENOMEM;
 


### PR DESCRIPTION
| fwparam_ppc.c:349:45: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
|   349 |                         dev = calloc(sizeof(struct ofw_dev), 1);
|       |                                             ^~~~~~
| fwparam_ppc.c:349:45: note: earlier argument should specify number of elements, later size of each element