### PR TITLE
iscsiuio/configure.ac: fix "subdir-objects" is disabled warning

### DIFF
--- a/iscsiuio/configure.ac
+++ b/iscsiuio/configure.ac
@@ -16,7 +16,7 @@ VERSION=0.7.8.8
 
 AC_INIT([iscsiuio], [0.7.8.8], [QLogic-Storage-Upstream@marvell.com])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADER(config.h)
 AC_PATH_PROGS(BASH, bash)
 


### PR DESCRIPTION
| src/unix/Makefile.am:12: warning: source file '${top_srcdir}/../utils/sysdeps/sysdeps.c' is in a subdirectory,
| src/unix/Makefile.am:12: but option 'subdir-objects' is disabled
| src/unix/libs/Makefile.am:10: warning: source file '../build_date.c' is in a subdirectory,
| src/unix/libs/Makefile.am:10: but option 'subdir-objects' is disabled