### PR TITLE
Makefile: fix "No rule to make target 'iscsiuio/Makefile.in" issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ user: deprecation_msg iscsiuio/Makefile
 	@echo
 	@echo "Read README file for detailed information."
 
-iscsiuio/Makefile: iscsiuio/configure iscsiuio/Makefile.in
+iscsiuio/Makefile: iscsiuio/configure
 	cd iscsiuio; ./configure $(WITHOUT_ARG) --sbindir=$(SBINDIR)
 
 iscsiuio/configure: iscsiuio/configure.ac iscsiuio/Makefile.am


### PR DESCRIPTION
| cd iscsiuio; autoreconf --install
| make: *** No rule to make target 'iscsiuio/Makefile.in', needed by 'iscsiuio/Makefile'.  Stop. | make: *** Waiting for unfinished jobs....
| libtoolize: putting auxiliary files in '.'

iscsiuio/Makefile.in will automatically generated when generate iscsiuio/configure by "cd iscsiuio; autoreconf --install", no need to explicitly specify