### PR TITLE
Fix a typo in initiator.c

### DIFF
--- a/usr/initiator.c
+++ b/usr/initiator.c
@@ -1504,7 +1504,7 @@ static void session_increase_wq_priority(struct iscsi_session *session)
 	closedir(proc_dir);
 fail:
 	log_warning("Could not set session%d priority. "
-		    "READ/WRITE throughout and latency could be affected.",
+		    "READ/WRITE throughput and latency could be affected.",
 		    session->id);
 }
 


### PR DESCRIPTION
There seems to be a typo in this warning regarding session priority. 
"throughout" should be throughput.

Thanks!