### PR TITLE
Ensure that iscsi.service is enabled when iscsid.service is enabled, and move Before= to a more appropriate target

### DIFF
--- a/etc/systemd/iscsi.service.template
+++ b/etc/systemd/iscsi.service.template
@@ -1,7 +1,7 @@
 [Unit]
 Description=Login and scanning of iSCSI devices
 Documentation=man:iscsiadm(8) man:iscsid(8)
-Before=remote-fs.target
+Before=remote-fs-pre.target
 After=network-online.target iscsid.service
 Requires=iscsid.socket iscsi-init.service
 Wants=network-online.target

--- a/etc/systemd/iscsid.service.template
+++ b/etc/systemd/iscsid.service.template
@@ -4,7 +4,7 @@ Documentation=man:iscsid(8) man:iscsiuio(8) man:iscsiadm(8)
 DefaultDependencies=no
 After=network-online.target iscsiuio.service iscsi-init.service
 Before=remote-fs-pre.target
-Wants=remote-fs-pre.target
+Wants=remote-fs-pre.target iscsi.service
 Requires=iscsi-init.service
 
 [Service]


### PR DESCRIPTION
iscsi.service exists to provide a mechanism to send an asynchronous signal to iscsid, so that it can reload its configuration on changes to the network status. Because it is an asynchronous signal, specifying that the unit must finish Before any other unit is ineffective.

Removing this setting will allow systems that do not mount any filesystems from iscsi targets to boot without unnecessary delays.