### PR TITLE
avoid possible double free of found in idbm_rec_update_param

### DIFF
--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -1167,8 +1167,10 @@ free_tmp:
 
 updated:
 	strlcpy((char*)info[i].value, value, VALUE_MAXVAL);
-	if (found)
+	if (found) {
 		free(found);
+		found = NULL;
+	}
 
 #define check_password_param(_param) \
 	if (!passwd_done && !strcmp(#_param, name)) { \


### PR DESCRIPTION
The found buffer allocated for TYPE_INT_LIST handling is freed in the updated path, but the pointer is not cleared afterwards.

Later, check_password_param() may redirect control flow back to setup_passwd_len via goto, causing idbm_rec_update_param() to re-enter the update path with found still containing the stale freed pointer value.

In that case, the second pass may reach the updated label without reinitializing found, leading to free(found) being executed again on the already freed pointer.

The issue can be avoided by clearing found after freeing it.