### PR TITLE
Fix find_vlan_dev -Wnonull

### DIFF
--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -323,8 +323,8 @@ int net_setup_netdev_ipv4(char *netdev, char *local_ip, char *mask, char *gatewa
 	vlan_id = atoi(vlan);
 
 	if (vlan_id != 0) {
-		vlandev = find_vlan_dev(physdev, vlan_id);
 		physdev = targetdev;
+		vlandev = find_vlan_dev(physdev, vlan_id);
 		targetdev = vlandev;
 	}
 
@@ -481,8 +481,8 @@ int net_setup_netdev_ipv6(char *netdev, char *local_ip, int prefix, char *gatewa
 
 	vlan_id = atoi(vlan);
 	if (vlan_id) {
-		vlandev = find_vlan_dev(physdev, vlan_id);
 		physdev = targetdev;
+		vlandev = find_vlan_dev(physdev, vlan_id);
 		targetdev = vlandev;
 	}
 	if (vlan_id && !vlandev) {


### PR DESCRIPTION
find_vlan_dev was being passed a constant NULL pointer for the netdev argument. This was accidental changed in a previous commit, by swapping the assignment of the variable and the function call. Assign variable before calling find_vlan_dev, like before change.

Fixes: 72c2b97c19a2 ("IPv6 support for iBFT iSCSI boot (#493)")
Fixes: #493 ("Introduce two separate variables to clearly distinguish their usage.")