### PR TITLE
iscsiuio: Fix -Waddress-of-packed-member

### DIFF
--- a/iscsiuio/src/uip/uip-neighbor.c
+++ b/iscsiuio/src/uip/uip-neighbor.c
@@ -185,16 +185,18 @@ void uip_neighbor_out(struct uip_stack *ustack)
 	    (struct uip_eth_hdr *)ustack->data_link_layer;
 	struct uip_ipv6_hdr *ipv6_hdr =
 	    (struct uip_ipv6_hdr *)ustack->network_layer;
+	struct in6_addr dst_addr6;
 
 	pthread_mutex_lock(&ustack->lock);
 
+	memcpy(&dst_addr6, ipv6_hdr->destipaddr, sizeof(dst_addr6));
 	/* Find the destination IP address in the neighbor table and construct
 	   the Ethernet header. If the destination IP addres isn't on the
 	   local network, we use the default router's IP address instead.
 
 	   If not ARP table entry is found, we overwrite the original IP
 	   packet with an ARP request for the IP address. */
-	e = find_entry(ustack, (struct in6_addr *)ipv6_hdr->destipaddr);
+	e = find_entry(ustack, &dst_addr6);
 	if (e == NULL) {
 		struct uip_eth_addr eth_addr_tmp;
 

--- a/iscsiuio/src/uip/uip_arp.c
+++ b/iscsiuio/src/uip/uip_arp.c
@@ -119,7 +119,7 @@ void uip_arp_timer(void)
 }
 
 /*----------------------------------------------------------------------------*/
-static void uip_arp_update(u16_t *ipaddr, struct uip_eth_addr *ethaddr)
+static void uip_arp_update(const u8_t *ipaddr, struct uip_eth_addr *ethaddr)
 {
 	u8_t i;
 	struct arp_entry *tabptr;
@@ -136,8 +136,8 @@ static void uip_arp_update(u16_t *ipaddr, struct uip_eth_addr *ethaddr)
 
 			/* Check if the source IP address of the incoming packet
 			   matches the IP address in this ARP table entry. */
-			if (ipaddr[0] == tabptr->ipaddr[0] &&
-			    ipaddr[1] == tabptr->ipaddr[1]) {
+			if (memcmp(ipaddr, tabptr->ipaddr,
+			    sizeof(tabptr->ipaddr)) == 0) {
 
 				tabptr->time = arptime;
 
@@ -216,7 +216,7 @@ void uip_arp_ipin(struct uip_stack *ustack, packet_t *pkt)
 		/* First, we register the one who made the request in our ARP
 		   table, since it is likely that we will do more communication
 		   with this host in the future. */
-		uip_arp_update(ip->srcipaddr, &eth->src);
+		uip_arp_update((const u8_t *)ip->srcipaddr, &eth->src);
 	}
 }
 
@@ -244,7 +244,7 @@ uip_arp_arpin(nic_interface_t *nic_iface,
 			/* First, we register the one who made the request in
 			   our ARP table, since it is likely that we will do
 			   more communication with this host in the future. */
-			uip_arp_update(arp->sipaddr, &arp->shwaddr);
+			uip_arp_update((const u8_t *)arp->sipaddr, &arp->shwaddr);
 
 			/* The reply opcode is 2. */
 			arp->opcode = htons(2);
@@ -270,7 +270,7 @@ uip_arp_arpin(nic_interface_t *nic_iface,
 		}
 		break;
 	case const_htons(ARP_REPLY):
-		uip_arp_update(arp->sipaddr, &arp->shwaddr);
+		uip_arp_update((const u8_t *)arp->sipaddr, &arp->shwaddr);
 		break;
 	default:
 		ILOG_WARN("Unknown ARP opcode: %d", ntohs(arp->opcode));


### PR DESCRIPTION
Fix -Waddress-of-packed-member warnings in
uip-neighbor.c:uip_neighbor_out by using memcpy().

Fix warings in uip-arp.c:uip_arp_update by changing the type of ipaddr to const u8_t * instead of u16_t *, and using memcmp() for comparison.