### PR TITLE
usr: Fix -Wdiscarded-qualifiers warning in iqn_name_valid

### DIFF
--- a/usr/initiator_common.c
+++ b/usr/initiator_common.c
@@ -765,10 +765,10 @@ int iscsi_host_set_net_params(struct iface_rec *iface,
 bool
 iqn_name_valid(const char *name)
 {
-	unsigned char *cp;
+	const unsigned char *cp;
 
 	/* ensure no invalid characters */
-	for (cp = name; *cp != '\0'; cp++)
+	for (cp = (const unsigned char *)name; *cp != '\0'; cp++)
 		if ((*cp <= '\x2c') ||
 		    (*cp == '\x2f') ||
 		    ((*cp >= '\x3b') && (*cp <= '\x40')) ||


### PR DESCRIPTION
The iqn_name_valid() function takes a const char * parameter, but assigns it to a non-const unsigned char * pointer, which triggers a -Werror=discarded-qualifiers build failure:

  initiator_common.c:771:17: error: assignment discards 'const'
  qualifier from pointer target type [-Werror=discarded-qualifiers]
    771 |         for (cp = name; *cp != '\0'; cp++)

Fix this by declaring cp as const unsigned char * and adding an explicit cast.