### PR TITLE
Fixes for CVEs CVE-2026-18724 - CVE-2026-18728

### DIFF
--- a/iscsiuio/src/apps/dhcpc/dhcpv6.c
+++ b/iscsiuio/src/apps/dhcpc/dhcpv6.c
@@ -258,6 +258,7 @@ void ipv6_udp_handle_dhcp(struct dhcpv6_context *context)
 {
 	union dhcpv6_hdr *dhcpv6;
 	u16_t dhcpv6_len;
+	u16_t udp_len = NET_TO_HOST16(context->udp->length);
 
 	if (context->dhcpv6_done == TRUE)
 		return;
@@ -273,8 +274,12 @@ void ipv6_udp_handle_dhcp(struct dhcpv6_context *context)
 		return;
 	}
 
-	dhcpv6_len =
-	    NET_TO_HOST16(context->udp->length) - sizeof(struct udp_hdr);
+	if (udp_len < sizeof(struct udp_hdr))
+		return;
+	dhcpv6_len = udp_len - sizeof(struct udp_hdr);
+
+	if (dhcpv6_len < sizeof(union dhcpv6_hdr))
+		return;
 
 	switch (dhcpv6->dhcpv6_type) {
 	case DHCPV6_ADVERTISE:

--- a/iscsiuio/src/uip/ipv6.c
+++ b/iscsiuio/src/uip/ipv6.c
@@ -852,21 +852,47 @@ static void ipv6_icmp_handle_router_adv(struct ipv6_context *context)
 	struct icmpv6_opt_hdr *icmp_opt;
 	u16_t opt_len;
 	u16_t len;
+	u16_t plen;
+	u16_t step;
 	char addr_str[INET6_ADDRSTRLEN];
 
 	if (context->flags & IPV6_FLAGS_ROUTER_ADV_RECEIVED)
 		return;
 
-	opt_len = HOST_TO_NET16(ipv6->ipv6_plen) -
-		  sizeof(struct icmpv6_router_advert);
+	plen = HOST_TO_NET16(ipv6->ipv6_plen);
+
+	/* Validate minimum payload length to prevent underflow */
+	if (plen < sizeof(struct icmpv6_router_advert)) {
+		ILOG_DEBUG("IPv6: RA payload too short (%u < %zu)",
+			   plen, sizeof(struct icmpv6_router_advert));
+		return;
+	}
+
+	opt_len = plen - sizeof(struct icmpv6_router_advert);
 
 	icmp_opt = (struct icmpv6_opt_hdr *)((u8_t *)icmp +
 				      sizeof(struct icmpv6_router_advert));
 	len = 0;
-	while (len < opt_len) {
+	/* Ensure there's space for option header before accessing it */
+	while (len + sizeof(struct icmpv6_opt_hdr) <= opt_len) {
 		icmp_opt = (struct icmpv6_opt_hdr *)((u8_t *)icmp +
 					sizeof(struct icmpv6_router_advert) +
 					len);
+
+		/* Reject zero-length options to prevent infinite loop */
+		if (icmp_opt->len == 0) {
+			ILOG_DEBUG("IPv6: RA option with zero length, stopping parse");
+			break;
+		}
+
+		/* Calculate step size (option length is in units of 8 bytes) */
+		step = icmp_opt->len * 8;
+
+		/* Validate step doesn't exceed remaining option space */
+		if (len + step > opt_len) {
+			ILOG_DEBUG("IPv6: RA option extends beyond payload");
+			break;
+		}
 
 		switch (icmp_opt->type) {
 		case IPV6_ICMP_OPTION_PREFIX:
@@ -879,7 +905,7 @@ static void ipv6_icmp_handle_router_adv(struct ipv6_context *context)
 			break;
 		}
 
-		len += icmp_opt->len * 8;
+		len += step;
 	}
 
 	if (context->flags & IPV6_FLAGS_ROUTER_ADV_RECEIVED) {

--- a/iscsiuio/src/uip/ipv6.c
+++ b/iscsiuio/src/uip/ipv6.c
@@ -1101,6 +1101,8 @@ static void ipv6_icmp_handle_echo_request(struct ipv6_context *context)
 {
 	struct eth_hdr *eth =
 			(struct eth_hdr *)context->ustack->data_link_layer;
+	u16_t rx_total, rx_payload, hdr_plen, safe_plen;
+	u16_t l2_l3_len = sizeof(struct eth_hdr) + sizeof(struct ipv6_hdr);
 	struct ipv6_hdr *ipv6 =
 			(struct ipv6_hdr *)context->ustack->network_layer;
 	struct icmpv6_hdr *icmp = (struct icmpv6_hdr *)((u8_t *)ipv6 +
@@ -1126,8 +1128,20 @@ static void ipv6_icmp_handle_echo_request(struct ipv6_context *context)
 	icmp->icmpv6_code = 0;
 	icmp->icmpv6_cksum = 0;
 	ILOG_DEBUG("IPv6: Send echo reply");
-	ipv6_send(context, (u8_t *) icmp - (u8_t *) eth +
-		  sizeof(struct ipv6_hdr) + HOST_TO_NET16(ipv6->ipv6_plen));
+
+	rx_total = context->ustack->uip_len;
+	if (rx_total <= l2_l3_len)
+		return;
+
+	rx_payload = rx_total - l2_l3_len;
+	hdr_plen = HOST_TO_NET16(ipv6->ipv6_plen);
+	safe_plen = (hdr_plen <= rx_payload) ? hdr_plen : rx_payload;
+	if (safe_plen < sizeof(struct icmpv6_hdr))
+		return;
+
+	ipv6->ipv6_plen = HOST_TO_NET16(safe_plen);
+	ipv6_send(context, l2_l3_len + safe_plen);
+
 	return;
 }
 

--- a/iscsiuio/src/uip/ipv6.c
+++ b/iscsiuio/src/uip/ipv6.c
@@ -1261,6 +1261,8 @@ static void ipv6_udp_rx(struct ipv6_context *context)
 	struct udp_hdr *udp = (struct udp_hdr *)((u8_t *)ipv6 +
 						sizeof(struct ipv6_hdr));
 	struct dhcpv6_context *dhcpv6c;
+	u16_t payload_len = NET_TO_HOST16(ipv6->ipv6_plen);
+	u16_t udp_length = NET_TO_HOST16(udp->length);
 
 	/*
 	 * We only care about DHCPv6 packets from the DHCPv6 server.  We drop
@@ -1269,6 +1271,14 @@ static void ipv6_udp_rx(struct ipv6_context *context)
 	if (!(context->flags & IPV6_FLAGS_DISABLE_DHCPV6)) {
 		if ((udp->src_port == HOST_TO_NET16(DHCPV6_SERVER_PORT)) &&
 		    (udp->dest_port == HOST_TO_NET16(DHCPV6_CLIENT_PORT))) {
+			/* Require minimal UDP + DHCPv6 fixed header and consistency */
+			if (payload_len < sizeof(struct udp_hdr) + sizeof(union dhcpv6_hdr))
+				return;
+			if (udp_length < sizeof(struct udp_hdr) + sizeof(union dhcpv6_hdr))
+				return;
+			if (udp_length > payload_len)
+				return;
+
 			dhcpv6c = context->dhcpv6_context;
 			dhcpv6c->eth = eth;
 			dhcpv6c->ipv6 = ipv6;

--- a/iscsiuio/src/uip/uip.c
+++ b/iscsiuio/src/uip/uip.c
@@ -1479,6 +1479,12 @@ udp_input:
 	   work. If the application sets uip_slen, it has a packet to
 	   send. */
 #if UIP_UDP_CHECKSUMS
+	if (ustack->uip_len < uip_ip_udph_len) {
+		++ustack->stats.udp.drop;
+		ILOG_DEBUG(PFX "udp: invalid IPv4 total length %u (< %u).",
+		           ustack->uip_len, uip_ip_udph_len);
+		goto drop;
+	}
 	ustack->uip_len = ustack->uip_len - uip_ip_udph_len;
 	ustack->uip_appdata = ustack->network_layer + uip_ip_udph_len;
 	if (UDPBUF(ustack)->udpchksum != 0 && uip_udpchksum(ustack) != 0xffff) {
@@ -1845,6 +1851,12 @@ found:
 	/* uip_len will contain the length of the actual TCP data. This is
 	   calculated by subtracing the length of the TCP header (in
 	   c) and the length of the IP header (20 bytes). */
+	if (ustack->uip_len < (u16_t)(c + uip_iph_len)) {
+		++ustack->stats.tcp.drop;
+		ILOG_DEBUG(PFX "tcp: invalid IPv4 total length %u (hdr=%u).",
+		           ustack->uip_len, (u16_t)(c + uip_iph_len));
+		goto drop;
+	}
 	ustack->uip_len = ustack->uip_len - c - uip_iph_len;
 
 	/* First, check if the sequence number of the incoming packet is

--- a/usr/idbm.c
+++ b/usr/idbm.c
@@ -1248,7 +1248,12 @@ void idbm_recinfo_config(recinfo_t *info, FILE *f)
 		/* parse name */
 		i=0; nl = line; *name = 0;
 		while (*nl && !isspace(c = *nl) && *nl != '=') {
-			*(name+i) = *nl; i++; nl++;
+			if (i >= NAME_MAXVAL - 1) {
+				log_warning("Config file line %d key too long.",
+					    line_number);
+				break;
+			}
+			name[i++] = *nl++;
 		}
 		if (!*nl) {
 			log_warning("Config file line %d does not have value",
@@ -1275,7 +1280,12 @@ void idbm_recinfo_config(recinfo_t *info, FILE *f)
 		/* parse value */
 		i=0; *value = 0;
 		while (*nl) {
-			*(value+i) = *nl; i++; nl++;
+			if (i >= VALUE_MAXVAL - 1) {
+				log_warning("Config file line %d value too long.",
+					    line_number);
+				break;
+			}
+			value[i++] = *nl++;
 		}
 		*(value+i) = 0;
 


### PR DESCRIPTION
CVE-2026-18724 Stack buffer overflow in idbm record parsing 
CVE-2026-18725 Out-of-bounds access in iscsiuio ICMPv6 echo handling
CVE-2026-18726 Denial of service in iscsiuio Router Advertisement parsing
CVE-2026-18727 Integer underflow in iscsiuio DHCPv6 parsing 
CVE-2026-18728 Integer underflow in iscsiuio IPv4 DHCP parsing

These fixes are all derived from the AI generated vulnerability reports
Related issue #543 