### PR TITLE
iscsi_net_util: fix broken VLAN support in find_vlan_dev

### DIFF
--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -185,7 +185,7 @@ free_ifni:
 	return 0;
 }
 
-static char *find_vlan_dev(int vlan_id) {
+static char *find_vlan_dev(char *netdev, int vlan_id) {
 	struct ifreq if_hwaddr;
 	struct ifreq vlan_hwaddr;
 	struct vlan_ioctl_args vlanrq = { .cmd = GET_VLAN_VID_CMD, };
@@ -199,6 +199,7 @@ static char *find_vlan_dev(int vlan_id) {
 		return NULL;
 	}
 
+	strlcpy(if_hwaddr.ifr_name, netdev, IFNAMSIZ);
 	ioctl(sockfd, SIOCGIFHWADDR, &if_hwaddr);
 
 	if (if_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER) {
@@ -322,8 +323,8 @@ int net_setup_netdev_ipv4(char *netdev, char *local_ip, char *mask, char *gatewa
 	vlan_id = atoi(vlan);
 
 	if (vlan_id != 0) {
-		vlandev = find_vlan_dev(vlan_id);
 		physdev = targetdev;
+		vlandev = find_vlan_dev(physdev, vlan_id);
 		targetdev = vlandev;
 	}
 
@@ -480,8 +481,8 @@ int net_setup_netdev_ipv6(char *netdev, char *local_ip, int prefix, char *gatewa
 
 	vlan_id = atoi(vlan);
 	if (vlan_id) {
-		vlandev = find_vlan_dev(vlan_id);
 		physdev = targetdev;
+		vlandev = find_vlan_dev(physdev, vlan_id);
 		targetdev = vlandev;
 	}
 	if (vlan_id && !vlandev) {


### PR DESCRIPTION
Commit 72c2b97c introduced a bug by passing physdev to find_vlan_dev() before it was initialized (physdev was set after the call instead of before). This was then made worse by commit 996269f which removed the netdev parameter entirely, leaving if_hwaddr.ifr_name uninitialized.

This fix:
- Restores the netdev parameter to find_vlan_dev()
- Re-adds the strlcpy() to initialize if_hwaddr.ifr_name
- Fixes the call order to set physdev before calling find_vlan_dev() in both net_setup_netdev_ipv4() and net_setup_netdev_ipv6()

I've briefly tested this with iscsistart -N with an iBFT table containing a VLAN
- 2.1.11 segfaults
- 2.1.12 fails to find the VLAN device
- 2.1.12 + this fix correctly configures the VLAN device