### PR TITLE
fix typo in user-facing error message in verify_mode_params()

### DIFF
--- a/usr/iscsiadm.c
+++ b/usr/iscsiadm.c
@@ -1374,7 +1374,7 @@ verify_mode_params(int argc, char **argv, enum iscsiadm_mode mode, const char *m
 	int tmp = optind;
 
 	if (mode > MODE_FW || mode < MODE_DISCOVERY) {
-		log_error("%s mode is unkonwn/unsupported", mode_str);
+		log_error("%s mode is unknown/unsupported", mode_str);
 		return ISCSI_ERR_INVAL;
 	}
 


### PR DESCRIPTION
I spotted a typo in an error message today while I was using iscsiadm. Here's a quick pull request to fix the typo — just changing "unkonwn" to "unknown".