### PR TITLE
Convert shell scripts to POSIX sh

### DIFF
--- a/etc/systemd/ibft-rule-generator
+++ b/etc/systemd/ibft-rule-generator
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Systemd rule generator for ibft interfaces
 #

--- a/iscsiuio/src/unix/build_date.sh
+++ b/iscsiuio/src/unix/build_date.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 #
 # build the build_date.c and build_date.h files
-#
-# (bash required for getopts)
 #
 
 THIS_CMD=${0##*/}

--- a/libopeniscsiusr/docs/list-man-pages.sh
+++ b/libopeniscsiusr/docs/list-man-pages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # list man pages found given one or more ??? passed in
 #

--- a/libopeniscsiusr/tests/runtest.sh
+++ b/libopeniscsiusr/tests/runtest.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ "CHK$TESTS"  == "CHK" ];then
+if [ "CHK$TESTS" = "CHK" ];then
     echo "# No test cases defined"
     exit 1
 fi
@@ -10,7 +10,7 @@ VALGRIND_OPTS="--quiet --leak-check=full \
                --show-reachable=no --show-possibly-lost=no \
                --trace-children=yes --error-exitcode=$VALGRIND_ERR_RC"
 
-TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 for TEST in $TESTS; do
     echo

--- a/utils/iscsi-gen-initiatorname.sh.template
+++ b/utils/iscsi-gen-initiatorname.sh.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # iscsi-gen-initiatorname
 #
@@ -88,13 +88,16 @@ usage_and_exit()
 #
 kernel_supplied_initiatorname()
 {
-    kcl="$(</proc/cmdline)"
-    if [[ "$kcl" =~ rd.initiatorname ]] ; then
+    kcl="$(cat /proc/cmdline)"
+    case "$kcl" in
+    *rd.initiatorname*)
 	kcl=${kcl##*rd.initiatorname=}
 	echo ${kcl%% *}
-    else
+	;;
+    *)
 	echo ""
-    fi
+	;;
+    esac
 }
 
 #
@@ -116,7 +119,7 @@ if [ "$#" -gt 0 ] ; then
     usage_and_exit 1
 fi
 
-if [ "$EUID" -ne 0 ] ; then
+if [ "$(id -u)" -ne 0 ] ; then
     echo "Error: You must be root to run this command" 1>&2
     usage_and_exit 1
 fi
@@ -134,7 +137,7 @@ KERNEL_INAME="$(kernel_supplied_initiatorname)"
 [ -r "$INAME_FILE" ] && . "$INAME_FILE"
 
 # if we have a local initiator name and "force" is not set end it now
-if [ "$InitiatorName" -a -z "$FORCE" ] ; then
+if [ "$InitiatorName" ] && [ -z "$FORCE" ] ; then
     echo "Error: you cannot overwrite the current InitiatorName unless 'force' is set." 1>&2
     usage_and_exit 1
 fi
@@ -155,7 +158,7 @@ fi
 
 # if we have both iBFT and kernel command line initiator names that
 # do not match end it now
-if [ "$IBFT_INAME" -a "$KERNEL_INAME" -a "$IBFT_INAME" != "$KERNEL_INAME" ] ; then
+if [ "$IBFT_INAME" ] && [ "$KERNEL_INAME" ] && [ "$IBFT_INAME" != "$KERNEL_INAME" ] ; then
     echo "Error: Kernel cmdline Initiator Name: $KERNEL_INAME" 1>&2
     echo "  does not match iBFT Initiator Name: $IBFT_INAME" 1>&2
     echo "Please ensure they both match, or remove the kernel parameter, then" 1>&2

--- a/utils/iscsi_discovery.sh
+++ b/utils/iscsi_discovery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (C) Voltaire Ltd. 2006.  ALL RIGHTS RESERVED.
 #
@@ -131,7 +131,7 @@ try_login()
 	ret=$?
 	if [ ${ret} = 0 ]; then
 		echo "Set target ${target} to automatic login over ${transport} to portal ${portal}"
-		((connected++))
+		connected=$((connected + 1))
 		if [ "$log_out" = "1" ]; then
 			iscsiadm -m node --targetname ${target} --portal ${portal} --logout
 		fi
@@ -170,7 +170,7 @@ select_transport()
 	set_transport $transport
 	dbg "Testing $transport-login to target ${target} portal ${portal}"
 	try_login;
-	if [ $? != 0 -a  "$force" = "0" ]; then
+	if [ $? != 0 ] && [ "$force" = "0" ]; then
 		set_transport tcp
 		dbg "starting to test tcp-login to target ${target} portal ${portal}"
 		try_login;
@@ -180,7 +180,7 @@ select_transport()
 check_iscsid()
 {
 	#check if iscsid is running
-	pidof iscsid &>/dev/null
+	pidof iscsid >/dev/null 2>&1
 	ret=$?
 	if [ $ret -ne 0 ]; then
 		echo "iscsid is not running"

--- a/utils/iscsi_fw_login.sh.template
+++ b/utils/iscsi_fw_login.sh.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # iscsi_fw_login -- login to iscsi firmware targets, if any
 #

--- a/utils/iscsi_offload.sh
+++ b/utils/iscsi_offload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # iscsi_offload
 #
@@ -50,11 +50,8 @@
 # cxgb3 is using one PCI device for everything.
 #
 iscsi_macaddress_from_pcidevice()
-{
-    local path=$1
-    local if=$2
-    local h
-    local host
+(
+    path=$1
 
     for h in $path/host* ; do
 	if [ -d "$h" ] ; then
@@ -69,7 +66,7 @@ iscsi_macaddress_from_pcidevice()
 	    fi
 	fi
     done
-}
+)
 
 #
 # Figure out the MAC address of the iSCSI offload engine
@@ -79,15 +76,12 @@ iscsi_macaddress_from_pcidevice()
 # Suitable for be2iscsi and qla4xxx
 #
 iscsi_macaddress_from_pcifn()
-{
-    local path=$1
-    local if=$2
-    local h
-    local host
-    local ifmac
-    local olemacoffset=$3
+(
+    path=$1
+    interface=$2
+    olemacoffset=$3
 
-    ifmac=$(ip addr show dev $if | sed -n 's/ *link\/ether \(.*\) brd.*/\1/p')
+    ifmac=$(ip addr show dev $interface | sed -n 's/ *link\/ether \(.*\) brd.*/\1/p')
     m5=$(( 0x${ifmac##*:} ))
     m5=$(( $m5 + $olemacoffset ))
     ifmac=$(printf "%s:%02x" ${ifmac%:*} $m5)
@@ -100,12 +94,12 @@ iscsi_macaddress_from_pcifn()
 	    fi
 	fi
     done
-}
+)
 
-update_iface_setting() {
-    local iface="$1"
-    local name="$2"
-    local value="$3"
+update_iface_setting() (
+    iface="$1"
+    name="$2"
+    value="$3"
 
     iface_value=$(iscsiadm -m iface -I $iface | sed -n "s/$name = \(.*\)/\1/p")
     if [ "$iface_value" = "<empty>" ] ; then
@@ -117,7 +111,7 @@ update_iface_setting() {
 	fi
     fi
     return 0
-}
+)
 
 while getopts di:t options ; do
     case $options in
@@ -222,7 +216,7 @@ elif [ "$mod" = "be2iscsi" ] ; then
     mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 1)
 elif [ "$mod" = "qla4xxx" ] ; then
     mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 1)
-elif [ "$mod" = "qede" -o "$mod" = "qedi" ] ; then
+elif [ "$mod" = "qede" ] || [ "$mod" = "qedi" ] ; then
     mac=$(iscsi_macaddress_from_pcifn $pcipath $IFNAME 4)
 fi
 
@@ -239,7 +233,7 @@ if iscsiadm -m iface -I $ioe_iface > /dev/null 2>&1 ; then
     ioe_mac=$(iscsiadm -m iface -I $ioe_iface 2> /dev/null| sed -n "s/iface\.hwaddress = \(.*\)/\1/p")
     ioe_mod=$(iscsiadm -m iface -I $ioe_iface 2> /dev/null| sed -n "s/iface\.transport_name = \(.*\)/\1/p")
     ipaddr=$(iscsiadm -m iface -I $ioe_iface 2> /dev/null| sed -n "s/iface\.ipaddress = \(.*\)/\1/p")
-    if [ "$ipaddr" == "<empty>" ] ; then
+    if [ "$ipaddr" = "<empty>" ] ; then
 	ipaddr=
     fi
 elif [ "$mod" = "be2iscsi" ] ; then
@@ -294,7 +288,7 @@ if [ -n "$iboot_dir" ] && [ -d "$iboot_dir" ] ; then
 	    ibft_mode="dhcp"
 	fi
 	[ -f $if/dhcp ] && read ibft_dhcp < $if/dhcp
-	if [ -n "$ibft_dhcp" -a "$ibft_mode" != "dhcp" ] ; then
+	if [ -n "$ibft_dhcp" ] && [ "$ibft_mode" != "dhcp" ] ; then
 	    ibft_mode=dhcp
 	fi
 	if [ "$ibft_mode" = "dhcp" ] ; then
@@ -381,4 +375,3 @@ fi
 ip link set dev $IFNAME up
 
 exit 0
-


### PR DESCRIPTION
These helpers do not require Bash. Remove Bash-specific syntax so they can run with /bin/sh on distributions where it is implemented by a non-Bash shell.