### PR TITLE
network code ioctl handling improvements

### DIFF
--- a/libopeniscsiusr/misc.c
+++ b/libopeniscsiusr/misc.c
@@ -135,13 +135,11 @@ bool _file_exists(const char *path)
 
 static bool _is_eth(struct iscsi_context *ctx, const char *if_name)
 {
-	struct ifreq ifr;
+	struct ifreq ifr = {0};
 	int sockfd = -1;
 	char strerr_buff[_STRERR_BUFF_LEN];
 
 	assert(if_name != NULL);
-
-	memset(&ifr, 0, sizeof(ifr));
 
 	_strncpy(ifr.ifr_name, if_name, IFNAMSIZ);
 
@@ -174,16 +172,13 @@ static int _eth_driver_get(struct iscsi_context *ctx, const char *if_name,
 			   char *driver_name)
 {
 	int sockfd = -1;
-	struct ethtool_drvinfo drvinfo;
-	struct ifreq ifr;
+	struct ethtool_drvinfo drvinfo = {0};
+	struct ifreq ifr = {0};
 	char strerr_buff[_STRERR_BUFF_LEN];
 
 	assert(ctx != NULL);
 	assert(if_name != NULL);
 	assert(driver_name != NULL);
-
-	memset(&ifr, 0, sizeof(ifr));
-	memset(&drvinfo, 0, sizeof(drvinfo));
 
 	_strncpy(ifr.ifr_name, if_name, IFNAMSIZ);
 	drvinfo.cmd = ETHTOOL_GDRVINFO;

--- a/usr/io.c
+++ b/usr/io.c
@@ -31,6 +31,7 @@
 #include <sys/uio.h>
 #include <ifaddrs.h>
 #include <netinet/in.h>
+#include <net/if_arp.h>
 
 #include "iface.h"
 #include "types.h"
@@ -87,7 +88,7 @@ static int get_hwaddress_from_netdev(char *netdev, char *hwaddress)
 	struct ifaddrs *ifap, *ifa;
 	struct sockaddr_in *s4;
 	struct sockaddr_in6 *s6;
-	struct ifreq if_hwaddr;
+	struct ifreq if_hwaddr = {0};
 	int found = 0, sockfd;
 	unsigned char *hwaddr;
 	char buf[INET6_ADDRSTRLEN];
@@ -140,7 +141,7 @@ static int get_hwaddress_from_netdev(char *netdev, char *hwaddress)
 		}
 
 		/* check for ARPHRD_ETHER (ethernet) */
-		if (if_hwaddr.ifr_hwaddr.sa_family != 1)
+		if (if_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER)
 			continue;
 		hwaddr = (unsigned char *)if_hwaddr.ifr_hwaddr.sa_data;
 
@@ -287,11 +288,10 @@ static int bind_conn_to_iface(iscsi_conn_t *conn, struct iface_rec *iface,
 	}
 
 	if (strlen(session->netdev)) {
-		struct ifreq ifr;
+		struct ifreq ifr = {0};
 
 		log_debug(4, "Binding session %d to %s", session->id,
 			  session->netdev);
-		memset(&ifr, 0, sizeof(ifr));
 		strlcpy(ifr.ifr_name, session->netdev, IFNAMSIZ);
 
 		if (!iscsi_conn_iface_has_ip(session->netdev, expected_family))

--- a/usr/iscsi_net_util.c
+++ b/usr/iscsi_net_util.c
@@ -63,10 +63,9 @@ static struct iscsi_net_driver net_drivers[] = {
 int net_get_transport_name_from_netdev(char *netdev, char *transport)
 {
 	struct ethtool_drvinfo drvinfo;
-	struct ifreq ifr;
+	struct ifreq ifr = {0};
 	int err, fd, i;
 
-	memset(&ifr, 0, sizeof(ifr));
 	strcpy(ifr.ifr_name, netdev);
 
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -127,7 +126,7 @@ close_sock:
 int net_get_netdev_from_hwaddress(char *hwaddress, char *netdev)
 {
 	struct if_nameindex *ifni;
-	struct ifreq if_hwaddr;
+	struct ifreq if_hwaddr = {0};
 	int found = 0, sockfd, i = 0;
 	unsigned char *hwaddr;
 	char tmp_hwaddress[ISCSI_HWADDRESS_BUF_SIZE];
@@ -157,7 +156,7 @@ int net_get_netdev_from_hwaddress(char *hwaddress, char *netdev)
 		}
 
 		/* check for ARPHRD_ETHER (ethernet) */
-		if (if_hwaddr.ifr_hwaddr.sa_family != 1)
+		if (if_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER)
 			continue;
 		hwaddr = (unsigned char *)if_hwaddr.ifr_hwaddr.sa_data;
 
@@ -186,8 +185,8 @@ free_ifni:
 }
 
 static char *find_vlan_dev(char *netdev, int vlan_id) {
-	struct ifreq if_hwaddr;
-	struct ifreq vlan_hwaddr;
+	struct ifreq if_hwaddr = {0};
+	struct ifreq vlan_hwaddr = {0};
 	struct vlan_ioctl_args vlanrq = { .cmd = GET_VLAN_VID_CMD, };
 	struct if_nameindex *ifni;
 	char *vlan = NULL;
@@ -200,7 +199,11 @@ static char *find_vlan_dev(char *netdev, int vlan_id) {
 	}
 
 	strlcpy(if_hwaddr.ifr_name, netdev, IFNAMSIZ);
-	ioctl(sockfd, SIOCGIFHWADDR, &if_hwaddr);
+	if (ioctl(sockfd, SIOCGIFHWADDR, &if_hwaddr) < 0) {
+		log_error("Could not match %s to netdevice.", netdev);
+		close(sockfd);
+		return NULL;
+	}
 
 	if (if_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER) {
 		close(sockfd);
@@ -216,7 +219,8 @@ static char *find_vlan_dev(char *netdev, int vlan_id) {
 
 	for (i = 0; ifni[i].if_index && ifni[i].if_name; i++) {
 		strlcpy(vlan_hwaddr.ifr_name, ifni[i].if_name, IFNAMSIZ);
-		ioctl(sockfd, SIOCGIFHWADDR, &vlan_hwaddr);
+		if (ioctl(sockfd, SIOCGIFHWADDR, &vlan_hwaddr) < 0)
+			continue;
 
 		if (vlan_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER)
 			continue;
@@ -258,11 +262,10 @@ int net_get_ip_version(char *ip)
 
 static int net_bringup_netdev(int sock, char *physdev, char *netdev)
 {
-	struct ifreq ifr;
 
 	if (physdev) {
 		/* Bring up interface */
-		memset(&ifr, 0, sizeof(ifr));
+		struct ifreq ifr = {0};
 		strlcpy(ifr.ifr_name, physdev, IFNAMSIZ);
 		ifr.ifr_flags = IFF_UP | IFF_RUNNING;
 		if (ioctl(sock, SIOCSIFFLAGS, &ifr) < 0) {
@@ -273,7 +276,7 @@ static int net_bringup_netdev(int sock, char *physdev, char *netdev)
 	}
 
 	/* Bring up interface */
-	memset(&ifr, 0, sizeof(ifr));
+	struct ifreq ifr = {0};
 	strlcpy(ifr.ifr_name, netdev, IFNAMSIZ);
 	ifr.ifr_flags = IFF_UP | IFF_RUNNING;
 	if (ioctl(sock, SIOCSIFFLAGS, &ifr) < 0) {

--- a/usr/transport.c
+++ b/usr/transport.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <libkmod.h>
 #include <net/if.h>
+#include <net/if_arp.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -144,7 +145,7 @@ int transport_probe_for_offload(void)
 	struct if_nameindex *ifni;
 	char transport_name[ISCSI_TRANSPORT_NAME_MAXLEN];
 	int i, sockfd;
-	struct ifreq if_hwaddr;
+	struct ifreq if_hwaddr = {0};
 
 	ifni = if_nameindex();
 	if (!ifni) {
@@ -170,7 +171,7 @@ int transport_probe_for_offload(void)
 			continue;
 
 		/* check for ARPHRD_ETHER (ethernet) */
-		if (if_hwaddr.ifr_hwaddr.sa_family != 1)
+		if (if_hwaddr.ifr_hwaddr.sa_family != ARPHRD_ETHER)
 			continue;
 
 		if (net_get_transport_name_from_netdev(n->if_name,


### PR DESCRIPTION
Replace explicit memset() calls with struct initialization at declaration, replace magic number 1 with ARPHRD_ETHER constant, and add missing error checks for ioctl(SIOCGIFHWADDR) calls in find_vlan_dev function.

fixes #547 