### PR TITLE
iscsiuio: validate DHCPv6 IA_NA option lengths to prevent OOB reads

### DIFF
--- a/iscsiuio/src/apps/dhcpc/dhcpv6.c
+++ b/iscsiuio/src/apps/dhcpc/dhcpv6.c
@@ -324,6 +324,14 @@ static void dhcpv6_handle_advertise(struct dhcpv6_context *context,
 						sizeof(union dhcpv6_hdr) + i);
 		opt_len = NET_TO_HOST16(opt->length);
 
+		/* Validate option length doesn't exceed remaining packet bytes */
+		int remaining = (dhcpv6_len - sizeof(union dhcpv6_hdr)) - i;
+		if (opt_len > remaining) {
+			ILOG_WARN("DHCPv6: option type %d length %d exceeds remaining %d bytes",
+				  NET_TO_HOST16(opt->type), opt_len, remaining);
+			break;
+		}
+
 		type = NET_TO_HOST16(opt->type);
 
 		/* We only care about some of the options */
@@ -403,18 +411,32 @@ static int dhcpv6_process_opt_ia_na(struct dhcpv6_context *context,
 	struct dhcpv6_option *opt;
 	int len;
 	int addr_cnt;
-	opt_len = NET_TO_HOST16(opt_hdr->length) -
-		  sizeof(struct dhcpv6_opt_id_assoc_na);
+	u16_t ia_na_len = NET_TO_HOST16(opt_hdr->length);
+
+	/* Validate IA_NA option is large enough for its fixed header */
+	if (ia_na_len < sizeof(struct dhcpv6_opt_id_assoc_na)) {
+		ILOG_WARN("DHCPv6: IA_NA option length %d too small", ia_na_len);
+		return 0;
+	}
+
+	opt_len = ia_na_len - sizeof(struct dhcpv6_opt_id_assoc_na);
 
 	i = 0;
 	addr_cnt = 0;
-	while (i < opt_len) {
+	while (i + (int)sizeof(struct dhcpv6_opt_hdr) <= opt_len) {
 		opt =
 		    (struct dhcpv6_option *)((u8_t *)opt_hdr +
 				     sizeof(struct dhcpv6_opt_hdr) +
 				     sizeof(struct dhcpv6_opt_id_assoc_na) + i);
 
 		len = NET_TO_HOST16(opt->hdr.length);
+
+		/* Validate sub-option length doesn't exceed remaining space */
+		if (len > opt_len - i) {
+			ILOG_WARN("DHCPv6: IA_NA sub-option length %d exceeds remaining %d bytes",
+				  len, opt_len - i);
+			break;
+		}
 		switch (NET_TO_HOST16(opt->hdr.type)) {
 		case DHCPV6_OPT_IAADDR:
 			if (len >


### PR DESCRIPTION
Add comprehensive length validation to DHCPv6 option parsing to prevent out-of-bounds reads when processing malformed ADVERTISE packets with forged IA_NA option lengths.

The DHCPv6 client code previously trusted option length fields from incoming packets without validating them against available packet data. An attacker on the same L2 segment could send a forged DHCPv6 ADVERTISE with an IA_NA option declaring length 0xFFFF, causing the parser to:

1. In dhcpv6_handle_advertise(): Read opt->length (line 326) and use it to advance the loop counter (line 365) without checking it doesn't exceed remaining packet bytes. This can walk the parser past the ~1500 byte packet buffer.

2. In dhcpv6_process_opt_ia_na(): Calculate opt_len as (untrusted_length
   - 12), potentially creating a huge value (e.g., 65523) that drives the sub-option loop far beyond the actual packet data.

3. Read opt->hdr.type/length at out-of-bounds offsets (line 418), triggering SIGSEGV on production heaps or leaking heap data into the IPv6 address table if the OOB read happens to match IAADDR structure.

This vulnerability requires:
- iscsiuio running with IPv6 DHCPv6 enabled (IPV6_CONFIG_DHCP)
- Link-local attacker presence (same L2 segment)
- Target in SOLICIT_SENT window with known transaction ID

Impact: Denial of service (root process crash) and potential IPv6 table pollution with heap-derived garbage addresses.

The fix adds three layers of validation:

1. In dhcpv6_handle_advertise(): After reading each option's declared length, validate it doesn't exceed remaining packet bytes. Log warning and stop parsing if exceeded.

2. In dhcpv6_process_opt_ia_na(): Validate the IA_NA option is at least large enough for its fixed header (12 bytes) before subtracting.

3. In the sub-option loop: Check sufficient space exists for the sub- option header before dereferencing, and validate each sub-option's length doesn't exceed remaining option space.

This prevents malformed packets from driving out-of-bounds reads while allowing legitimate DHCPv6 traffic to parse correctly.

Reported-by: Kimi Security Team <bug-report@moonshot.ai>
Resolves: Adjacent network DoS via DHCPv6 IA_NA length overflow